### PR TITLE
[#3] ResponseDto 개선 작업

### DIFF
--- a/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
+++ b/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
@@ -1,0 +1,41 @@
+package com.hello.boilerplate.global.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+
+	private final boolean success;
+	private final String statusName;
+	private final String message;
+	private final T response;
+
+	@Builder
+	private ResponseDto(boolean success, String statusName, String message, T response) {
+		this.success = success;
+		this.statusName = statusName;
+		this.message = message;
+		this.response = response;
+	}
+
+	public static <T> ResponseDto<T> success(HttpStatus status, String message, T data) {
+		return ResponseDto.<T>builder()
+			.success(true)
+			.statusName(status.name())
+			.message(message)
+			.response(data)
+			.build();
+	}
+
+	public static <T> ResponseDto<T> fail(HttpStatus status, String message) {
+		return ResponseDto.<T>builder()
+			.success(false)
+			.statusName(status.name())
+			.message(message)
+			.response(null)
+			.build();
+	}
+}

--- a/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
+++ b/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
@@ -2,40 +2,52 @@ package com.hello.boilerplate.global.dto;
 
 import org.springframework.http.HttpStatus;
 
+import com.hello.boilerplate.global.exception.ErrorCode;
+
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class ResponseDto<T> {
 
-	private final boolean success;
-	private final String statusName;
+	private final String statusCode;
 	private final String message;
-	private final T response;
+	private final String errorCode;
+	private final T data;
 
-	@Builder
-	private ResponseDto(boolean success, String statusName, String message, T response) {
-		this.success = success;
-		this.statusName = statusName;
+	@Builder(access = AccessLevel.PRIVATE)
+	private ResponseDto(String statusCode, String message, String errorCode, T data) {
+		this.statusCode = statusCode;
 		this.message = message;
-		this.response = response;
+		this.errorCode = errorCode;
+		this.data = data;
 	}
 
-	public static <T> ResponseDto<T> success(HttpStatus status, String message, T data) {
+	public static <T> ResponseDto<T> ofSuccess(HttpStatus status, T data) {
 		return ResponseDto.<T>builder()
-			.success(true)
-			.statusName(status.name())
-			.message(message)
-			.response(data)
+			.statusCode(status.name())
+			.message(null)
+			.errorCode(null)
+			.data(data)
 			.build();
 	}
 
-	public static <T> ResponseDto<T> fail(HttpStatus status, String message) {
+	public static <T> ResponseDto<T> ofSuccess(HttpStatus status, String message, T data) {
 		return ResponseDto.<T>builder()
-			.success(false)
-			.statusName(status.name())
+			.statusCode(status.name())
 			.message(message)
-			.response(null)
+			.errorCode(null)
+			.data(data)
+			.build();
+	}
+
+	public static <T> ResponseDto<T> fromErrorCode(ErrorCode errorCode) {
+		return ResponseDto.<T>builder()
+			.statusCode(errorCode.getHttpStatus().name())
+			.message(errorCode.getMessage())
+			.errorCode(errorCode.name())
+			.data(null)
 			.build();
 	}
 }

--- a/src/main/java/com/hello/boilerplate/global/exception/ErrorCode.java
+++ b/src/main/java/com/hello/boilerplate/global/exception/ErrorCode.java
@@ -1,0 +1,52 @@
+package com.hello.boilerplate.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	/**
+	 * 400 BAD_REQUEST : 잘못된 요청
+	 */
+	INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 데이터"),
+
+	/**
+	 * 401 UNAUTHORIZED : 인증 되지 않은 사용자
+	 */
+	AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증 필요"),
+	INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "권한 정보가 없는 토큰"),
+	EXPIRED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 만료"),
+
+	/**
+	 * 403 FORBIDDEN : 권한 없음
+	 */
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한 없음"),
+
+	/**
+	 * 404 NOT_FOUND : Resource 를 찾을 수 없음
+	 */
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자 없음"),
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 리소스 없음"),
+
+	/**
+	 * 409 : CONFLICT : Resource 의 현재 상태와 충돌
+	 */
+	DUPLICATE_LOGINID(HttpStatus.CONFLICT, "아이디 중복"),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이메일 중복"),
+	DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "중복 데이터"),
+	RESOURCE_CONFLICT(HttpStatus.CONFLICT, "리소스 상태 충돌"),
+	OVER_VALIDATION(HttpStatus.CONFLICT, "저장 한도 초과"),
+
+	/**
+	 * 500 INTERNAL_SERVER_ERROR : 서버 오류
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류"),
+	EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 API 호출 실패");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/test/java/com/hello/boilerplate/global/dto/ResponseDtoTest.java
+++ b/src/test/java/com/hello/boilerplate/global/dto/ResponseDtoTest.java
@@ -1,0 +1,70 @@
+package com.hello.boilerplate.global.dto;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import com.hello.boilerplate.global.exception.ErrorCode;
+
+class ResponseDtoTest {
+
+	@Test
+	@DisplayName("상태, 데이터가 주어졌을 때 성공 응답을 만듭니다")
+	void shouldCreateSuccessResponseWhenStatusAndDataGiven() {
+		//given
+		HttpStatus status = HttpStatus.OK;
+		String data = "testData";
+
+		//when
+		ResponseDto<String> responseDto = ResponseDto.ofSuccess(status, data);
+
+		//then
+		assertAll(
+			() -> assertThat(responseDto.getStatusCode()).isEqualTo(status.name()),
+			() -> assertThat(responseDto.getMessage()).isNull(),
+			() -> assertThat(responseDto.getErrorCode()).isNull(),
+			() -> assertThat(responseDto.getData()).isEqualTo(data)
+		);
+	}
+
+	@Test
+	@DisplayName("상태, 데이터, 메세지가 주어졌을 때 메세지를 포함한 성공 응답을 만듭니다")
+	void shouldCreateSuccessResponseWithMessageWhenStatusAndDataAndMessageGiven() {
+	    //given
+		HttpStatus status = HttpStatus.OK;
+		String message = "testMessage";
+		String data = "testData";
+
+	    //when
+		ResponseDto<String> responseDto = ResponseDto.ofSuccess(status, message, data);
+
+		//then
+	    assertAll(
+	        () -> assertThat(responseDto.getStatusCode()).isEqualTo(status.name()),
+			() -> assertThat(responseDto.getMessage()).isEqualTo(message),
+			() -> assertThat(responseDto.getErrorCode()).isNull(),
+	        () -> assertThat(responseDto.getData()).isEqualTo(data)
+	    );
+	}
+
+	@Test
+	@DisplayName("에러 코드가 주어졌을 때 에러 응답을 생성합니다")
+	void shouldCreateErrorResponseWhenErrorCodeGiven() {
+		//given
+		ErrorCode internalServerError = ErrorCode.INTERNAL_SERVER_ERROR;
+
+		//when
+		ResponseDto<String> responseDto = ResponseDto.fromErrorCode(internalServerError);
+
+		//then
+		assertAll(
+			() -> assertThat(responseDto.getStatusCode()).isEqualTo(internalServerError.getHttpStatus().name()),
+			() -> assertThat(responseDto.getMessage()).isEqualTo(internalServerError.getMessage()),
+			() -> assertThat(responseDto.getErrorCode()).isEqualTo(internalServerError.name()),
+			() -> assertThat(responseDto.getData()).isNull()
+		);
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#3 ]

### 변경 사항

#### 1. 필드 변경

다양한 기업의 홈페이지를 참고하여 ResponseDto의 레퍼런스를 확보했습니다.
대표적으로 인프런의 ResponseDto를 참고하여 제작하였습니다.
인프런의 ResponseDto의 구조는 아래와 같습니다.

성공 응답
<img width="387" height="629" alt="인프런" src="https://github.com/user-attachments/assets/5faece5a-2775-496c-9e70-66c141a2c8bf" />

에러 응답
<img width="872" height="60" alt="인프런에러" src="https://github.com/user-attachments/assets/ed19ccbb-5d87-4dbc-893f-6c442d7beb87" />

인프런의 구조를 참고하여 기존의 필드를 일부 수정하였습니다.

변경 전
```java
@Getter
public class ResponseDto<T> {

	private final boolean success;
	private final String statusName;
	private final String message;
	private final T response;

// 생략
```

변경 후 
```java
@Getter
public class ResponseDto<T> {

	private final String statusCode;
	private final String message;
	private final String errorCode;
	private final T data;

// 생략
```

#### 2. Builder의 private 옵션

빌더의 어노테이션을 확인한 결과 기본 옵션이 public으로 확인되었습니다.
팩토리 메서드만을 사용하여 객체를 생성하기 때문에 외부에서의 선언을 막고자 builder에 private 옵션을 추가했습니다.

#### 3. 오버로딩 사용

인프런의 ResponseDto를 참고한 결과 message 필드는 디테일적인 설명이 필요한 경우 사용되는것으로 판단이 되었습니다. 그리고 HTTP 메소드로 요청의 결과를 이해하는것이 Restful 한 모습이라고 생각합니다. 
따라서, message가 있는 경우와 message가 없는 경우 총 2개의 팩토리 메서드를 제작하였습니다.
디테일한 설명이 필요한 경우에 사용할 수 있습니다.

```java
public static <T> ResponseDto<T> ofSuccess(HttpStatus status, T data) {
		return ResponseDto.<T>builder()
			.statusCode(status.name())
			.message(null)
			.errorCode(null)
			.data(data)
			.build();
	}

	public static <T> ResponseDto<T> ofSuccess(HttpStatus status, String message, T data) {
		return ResponseDto.<T>builder()
			.statusCode(status.name())
			.message(message)
			.errorCode(null)
			.data(data)
			.build();
	}
```

4. 에러 응답 개선

기존 에러 응답 생성 메서드의 파라미터의 경우에는 HttpStatus status, String message 를 받아서 생성하게 되었습니다. ErrorCode에 정의된 내용에 따라 편하게 설정되도록 파라미터를 ErrorCode로 받도록 수정했습니다.

### 테스트 결과

<img width="540" height="144" alt="response_dto_test_success" src="https://github.com/user-attachments/assets/56223828-82a1-4c39-a1a8-87c049b44705" />

+추가적으로 테스트 코드의 네이밍 컨벤션의 경우 should + 동작 + 조건 으로 일관성있게 진행하였습니다. 문서에 추후에 업로드 예정입니다.
