### PR TITLE
[#3] 에러 응답 dto 제네릭 메서드 제거

### DIFF
--- a/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
+++ b/src/main/java/com/hello/boilerplate/global/dto/ResponseDto.java
@@ -42,8 +42,8 @@ public class ResponseDto<T> {
 			.build();
 	}
 
-	public static <T> ResponseDto<T> fromErrorCode(ErrorCode errorCode) {
-		return ResponseDto.<T>builder()
+	public static ResponseDto<Void> fromErrorCode(ErrorCode errorCode) {
+		return ResponseDto.<Void>builder()
 			.statusCode(errorCode.getHttpStatus().name())
 			.message(errorCode.getMessage())
 			.errorCode(errorCode.name())

--- a/src/test/java/com/hello/boilerplate/global/dto/ResponseDtoTest.java
+++ b/src/test/java/com/hello/boilerplate/global/dto/ResponseDtoTest.java
@@ -57,7 +57,7 @@ class ResponseDtoTest {
 		ErrorCode internalServerError = ErrorCode.INTERNAL_SERVER_ERROR;
 
 		//when
-		ResponseDto<String> responseDto = ResponseDto.fromErrorCode(internalServerError);
+		ResponseDto<Void> responseDto = ResponseDto.fromErrorCode(internalServerError);
 
 		//then
 		assertAll(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#3 ](이슈 링크)

### 변경 사항
에러 응답시 T data가 null 입니다.
제네릭 메서드가 불필요하다고 판단했습니다.
제네릭 메서드를 삭제하고 응답을 Void로 하여, 응답 data가 없다는것을 표현하도록 수정했습니다.

