### PR TITLE
[#9] 쿠키 유틸 클래스 추가

### DIFF
--- a/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
+++ b/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
@@ -1,0 +1,34 @@
+package com.hello.boilerplate.global.utils;
+
+import org.springframework.http.ResponseCookie;
+
+import com.hello.boilerplate.global.exception.CustomException;
+import com.hello.boilerplate.global.exception.ErrorCode;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class CookieUtil {
+
+	public static ResponseCookie createCookie(String name, String value, long cookieExpiration) {
+		return ResponseCookie.from(name, value)
+			.maxAge(cookieExpiration)
+			.path("/")
+			.sameSite("None")
+			.secure(true)
+			.httpOnly(true)
+			.build();
+	}
+
+	public static Cookie findCookieByName(HttpServletRequest request, String name) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if (cookie.getName().equals(name)) {
+					return cookie;
+				}
+			}
+		}
+		throw new CustomException(ErrorCode.INVALID_REQUEST);
+	}
+}

--- a/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
+++ b/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
@@ -7,14 +7,33 @@ import com.hello.boilerplate.global.exception.ErrorCode;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CookieUtil {
 
+	private static final String DEFAULT_PATH = "/";
+	private static final String DEFAULT_SAME_SITE = "None";
+
+
 	public static ResponseCookie of(String name, String value, long cookieExpiration) {
+		validateCookieName(name);
 		return ResponseCookie.from(name, value)
 			.maxAge(cookieExpiration)
-			.path("/")
-			.sameSite("None")
+			.path(DEFAULT_PATH)
+			.sameSite(DEFAULT_SAME_SITE)
+			.secure(true)
+			.httpOnly(true)
+			.build();
+	}
+
+	public static ResponseCookie ofExpired(String name) {
+		validateCookieName(name);
+		return ResponseCookie.from(name, "")
+			.maxAge(0)
+			.path(DEFAULT_PATH)
+			.sameSite(DEFAULT_SAME_SITE)
 			.secure(true)
 			.httpOnly(true)
 			.build();
@@ -30,5 +49,11 @@ public final class CookieUtil {
 			}
 		}
 		throw new CustomException(ErrorCode.INVALID_REQUEST);
+	}
+
+	private static void validateCookieName(String cookieName) {
+		if (cookieName == null || cookieName.isEmpty()) {
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
 	}
 }

--- a/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
+++ b/src/main/java/com/hello/boilerplate/global/utils/CookieUtil.java
@@ -10,7 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 public final class CookieUtil {
 
-	public static ResponseCookie createCookie(String name, String value, long cookieExpiration) {
+	public static ResponseCookie of(String name, String value, long cookieExpiration) {
 		return ResponseCookie.from(name, value)
 			.maxAge(cookieExpiration)
 			.path("/")

--- a/src/test/java/com/hello/boilerplate/global/utils/CookieUtilTest.java
+++ b/src/test/java/com/hello/boilerplate/global/utils/CookieUtilTest.java
@@ -1,0 +1,139 @@
+package com.hello.boilerplate.global.utils;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+
+import com.hello.boilerplate.global.exception.CustomException;
+import com.hello.boilerplate.global.exception.ErrorCode;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+class CookieUtilTest {
+
+	private static final String COOKIE_NAME = "cookieName";
+	private static final String COOKIE_VALUE = "cookieValue";
+	private static final long COOKIE_EXPIRATION = 86400;
+
+	@Test
+	@DisplayName("쿠키를 정상적으로 발급한다")
+	void shouldOfWhenNameValueAndMaxAgeGiven() {
+		// when
+		ResponseCookie cookie = CookieUtil.of(COOKIE_NAME, COOKIE_VALUE, COOKIE_EXPIRATION);
+
+		// then
+		assertAll(
+			() -> assertThat(cookie).isNotNull(),
+			() -> assertThat(cookie.getName()).isEqualTo(COOKIE_NAME),
+			() -> assertThat(cookie.getValue()).isEqualTo(COOKIE_VALUE),
+			() -> assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(COOKIE_EXPIRATION),
+			() -> assertThat(cookie.getPath()).isEqualTo("/"),
+			() -> assertThat(cookie.getSameSite()).isEqualTo("None"),
+			() -> assertThat(cookie.isHttpOnly()).isTrue()
+		);
+	}
+
+	@Test
+	@DisplayName("무효화 쿠키를 정상적으로 발급한다")
+	void shouldOfExpiredWhenNameGiven() {
+		// when
+		ResponseCookie cookie = CookieUtil.ofExpired(COOKIE_NAME);
+
+		// then
+		assertAll(
+			() -> assertThat(cookie).isNotNull(),
+			() -> assertThat(cookie.getName()).isEqualTo(COOKIE_NAME),
+			() -> assertThat(cookie.getValue()).isEqualTo(""),
+			() -> assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(0),
+			() -> assertThat(cookie.getPath()).isEqualTo("/"),
+			() -> assertThat(cookie.getSameSite()).isEqualTo("None"),
+			() -> assertThat(cookie.isHttpOnly()).isTrue()
+		);
+	}
+
+	@Test
+	@DisplayName("쿠키의 이름이 null이면 예외를 던진다")
+	void shouldThrowExceptionWhenNameIsNullOnOf() {
+		// then
+		assertThatThrownBy(() -> CookieUtil.of(null, COOKIE_VALUE, COOKIE_EXPIRATION))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+	}
+
+	@Test
+	@DisplayName("무효화 쿠키의 이름이 null이면 예외를 던진다")
+	void shouldThrowExceptionWhenNameIsNullOnExpired() {
+		// then
+		assertThatThrownBy(() -> CookieUtil.ofExpired(null))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+	}
+
+	@Test
+	@DisplayName("쿠키의 이름이 비어있으면 예외를 던진다")
+	void shouldThrowExceptionWhenNameIsBlankOnOf() {
+		// then
+		assertThatThrownBy(() -> CookieUtil.of(null, COOKIE_VALUE, COOKIE_EXPIRATION))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+	}
+
+	@Test
+	@DisplayName("무효화 쿠키의 이름이 비어있으면 예외를 던진다")
+	void shouldThrowExceptionWhenNameIsBlankOnExpired() {
+		// then
+		assertThatThrownBy(() -> CookieUtil.ofExpired(null))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+	}
+
+	@Test
+	@DisplayName("찾는 이름의 쿠키가 요청에서 조회된다")
+	void shouldFindCookieByNameWhenCookieExistsInRequest() {
+		// given
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		Cookie[] mockCookies = {new Cookie(COOKIE_NAME, COOKIE_VALUE)};
+
+		// when
+		when(request.getCookies()).thenReturn(mockCookies);
+		Cookie cookie = CookieUtil.findCookieByName(request, COOKIE_NAME);
+
+		// then
+		assertAll(
+			() -> assertThat(cookie).isNotNull(),
+			() -> assertThat(cookie.getName()).isEqualTo(COOKIE_NAME),
+			() -> assertThat(cookie.getValue()).isEqualTo(COOKIE_VALUE)
+		);
+	}
+
+	@Test
+	@DisplayName("찾는 이름의 쿠키가 요청에 없을 경우 예외를 던진다")
+	void shouldThrowExceptionWhenCookieNameNotFoundInRequest() {
+		// given
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		Cookie[] mockCookies = {new Cookie("differentCookie", COOKIE_VALUE)};
+		when(request.getCookies()).thenReturn(mockCookies);
+
+		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INVALID_REQUEST.getMessage());
+	}
+
+	@Test
+	@DisplayName("요청된 쿠키가 없는 경우 예외를 던진다")
+	void shouldThrowExceptionWhenRequestCookiesIsNull() {
+		//given
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getCookies()).thenReturn(null);
+
+		// when & then
+		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining(ErrorCode.INVALID_REQUEST.getMessage());
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#9 ](이슈 링크)

### 변경 사항
쿠키 유틸 클래스를 제작했습니다.
기존 쿠키 유틸 클래스에서 일부 개선했습니다.

1. 외부 인스턴스 생성 방지
```java
@NoArgsConstructor(access = AccessLevel.PRIVATE)
```
외부에서 쿠키 유틸 클래스를 선언하지 못하도록 개선했습니다.


2. 상수 처리
```java
private static final String DEFAULT_PATH = "/";
private static final String DEFAULT_SAME_SITE = "None";
```
of와 ofExpired에서 사용하기 위해 하드코딩 된 부분을 상수로 처리 했습니다.


4. 무효화 기능 추가
```java
public static ResponseCookie ofExpired(String name) {
		validateCookieName(name);
		return ResponseCookie.from(name, "")
			.maxAge(0)
			.path(DEFAULT_PATH)
			.sameSite(DEFAULT_SAME_SITE)
			.secure(true)
			.httpOnly(true)
			.build();
	}
```


5. 쿠키명 validation 추가
```java
private static void validateCookieName(String cookieName) {
		if (cookieName == null || cookieName.isEmpty()) {
			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
		}
	}
```
쿠키명을 정하지 않을 경우의 NPE를 방지하기 위한 validation 메서드를 추가했습니다.

### 테스트 결과
<img width="542" height="289" alt="스크린샷 2025-09-09 오전 3 06 11" src="https://github.com/user-attachments/assets/03081109-72be-4cf9-9b29-66e97594086d" />


