### PR TITLE
[#11] jacoco 테스트 커버리지 분석 도구 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.hello'
@@ -11,6 +12,10 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+}
+
+jacoco {
+    toolVersion = "0.8.10"
 }
 
 configurations {
@@ -45,6 +50,46 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+// 제외할 디렉토리 및 파일 패턴을 공통 변수로 선언
+ext.jacocoExcludes = [
+        "**/dto/**",       // DTO 클래스
+        "**/exception/**", // 커스텀 예외
+        "**/config/**",    // 설정 파일
+]
+
+tasks.named('jacocoTestReport') {
+    dependsOn(tasks.named('test')) // 테스트 실행 후 리포트 생성
+    reports {
+        xml.required = true // SonarQube를 위한 XML 리포트 생성
+        html.required = true // 사람이 읽기 쉬운 HTML 리포트 생성
+        csv.required = false // CSV 리포트는 비활성화
+    }
+    classDirectories.setFrom(
+            files(classDirectories.files.collect { dir ->
+                fileTree(dir) {
+                    exclude jacocoExcludes // 리포트 생성에서 제외할 디렉토리와 파일 설정
+                }
+            })
+    )
+
+    finalizedBy tasks.named('jacocoTestCoverageVerification') // 리포트 생성 후 검증
+}
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = "BUNDLE" // 전체 모듈 수준에서 통합 커버리지 검증
+
+            limit {
+                counter = "INSTRUCTION" // 라인 커버리지 기준
+                value = "COVEREDRATIO"
+                minimum = 0.30
+            }
+            excludes = jacocoExcludes
+        }
+    }
 }
 
 tasks.named('test') {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#11 ](이슈 링크)

### 변경 사항
1. Jacoco 테스트 커버리지 분석 도구를 추가

커버리지의 경우에는 30프로로 낮게 설정했으며, 추후에 프로젝트에 맞는 커버리지 수준으로 변경할 예정입니다.

2. Jacoco 결과

일반 적인 코드 작성 방식으로 진행하면
테스트 결과 -> 커버리지 확인 -> 테스트 보완 -> 테스트 결과 -> 커버리지 확인
의 흐름으로 진행하였습니다.

TDD 방식으로 구현 할 경우 Red -> Green -> Refactor 의 흐름으로 진행하였습니다.
테스트 커버리지를 괜찮은 수준으로 처음 부터 지킬 수 있다고 느꼈습니다.
앞으로 추가 될 기능에 대해 일부는 TDD를 사용해보며, 더 정확한 이점을 느끼기 위해 차이를 경험해볼 예정입니다.


### 테스트 결과
<img width="1077" height="208" alt="스크린샷 2025-09-11 오후 8 36 00" src="https://github.com/user-attachments/assets/46f9e211-050f-4800-910b-21fe76659783" />


