### PR TITLE
[#41] API 문서 리펙토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ openapi3 {
     ]
     title = 'Boiler Plate API'
     description = 'Boiler Plate API'
-    version = '0.0.1'
+    version = new Date().format("yyyy.MM.dd HH:mm")
     format = 'yaml'
 }
 

--- a/src/main/resources/static/swagger-ui/swagger-ui.html
+++ b/src/main/resources/static/swagger-ui/swagger-ui.html
@@ -33,19 +33,22 @@
 <script src="./js/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
 <script>
   window.onload = function () {
-    const ui = SwaggerUIBundle({
-      url: "./openapi3.yaml",
-      dom_id: '#swagger-ui',
-      deepLinking: true,
-      presets: [
-        SwaggerUIBundle.presets.apis,
-        SwaggerUIStandalonePreset
-      ],
-      plugins: [
-        SwaggerUIBundle.plugins.DownloadUrl
-      ],
-      layout: "StandaloneLayout"
-    });
+      const ui = SwaggerUIBundle({
+          urls: [
+              { url: "./openapi3.yaml", name: "통합 API 문서" },
+              { url: "./openapi3.yaml", name: "준비 중 (MSA 전환 시 추가 예정)" }
+          ],
+          dom_id: '#swagger-ui',
+          deepLinking: true,
+          presets: [
+              SwaggerUIBundle.presets.apis,
+              SwaggerUIStandalonePreset
+          ],
+          plugins: [
+              SwaggerUIBundle.plugins.DownloadUrl
+          ],
+          layout: "StandaloneLayout"
+      });
     window.ui = ui;
   };
 </script>

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -19,12 +19,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -58,6 +60,7 @@ class AuthControllerTest extends RestDocsSupport {
 				post(BASE_URI + "/login")
 					.content(objectMapper.writeValueAsString(requestDto))
 					.contentType(MediaType.APPLICATION_JSON)
+
 			);
 
 			//then
@@ -78,10 +81,14 @@ class AuthControllerTest extends RestDocsSupport {
 								+ "- accessToken이란? 권한이 필요한 API에 함께 보내야되는 인증 토큰입니다.\n"
 								+ "- refreshToken이란? accessToken이 만료되어 새로 발급받아야할 때 사용되는 토큰입니다.\n"
 							)
-							.requestSchema(Schema.schema("AuthenticateUser"))
+							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
 							.requestFields(
 								fieldWithPath("loginId").description("아이디는 영문 4자리 이상입니다.").type(JsonFieldType.STRING),
 								fieldWithPath("password").description("비밀번호는 특수문자를 포함한 영문과 숫자 8자리 이상입니다.").type(JsonFieldType.STRING)
+							)
+							.responseHeaders(
+								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰입니다."),
+								headerWithName(HttpHeaders.SET_COOKIE).description("재발급 토큰 쿠키입니다.")
 							)
 							.build()
 						)
@@ -112,6 +119,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -143,6 +151,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -174,6 +183,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -192,7 +202,7 @@ class AuthControllerTest extends RestDocsSupport {
 			//when
 			ResultActions actions = mockMvc.perform(
 				post(BASE_URI + "/logout")
-					.contentType(MediaType.APPLICATION_JSON));
+			);
 
 			//then
 			actions
@@ -242,6 +252,9 @@ class AuthControllerTest extends RestDocsSupport {
 								+ "### 사용법 \n"
 								+ "- 재발급 시 새로운 엑세스 토큰을 헤더에 응답합니다.\n"
 								+ "- 401이 뜬다면, 재로그인이 필요합니다.\n"
+							)
+							.responseHeaders(
+								headerWithName(HttpHeaders.AUTHORIZATION).description("새로운 엑세스 토큰입니다.")
 							)
 							.build()
 						)

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -221,6 +221,9 @@ class AuthControllerTest extends RestDocsSupport {
 							.summary("로그아웃")
 							.description("- 로그아웃 입니다. 브라우저 쿠키를 초기화 합니다.")
 							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.responseHeaders(
+								headerWithName(HttpHeaders.SET_COOKIE).description("초기화 쿠키 입니다.")
+							)
 							.build()
 						)
 					)

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -8,6 +8,8 @@ import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
+import com.hello.boilerplate.common.presentation.dto.ApiErrorResponse;
+import com.hello.boilerplate.common.presentation.dto.ApiResponse;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.support.fixture.UserFixture;
 import com.hello.boilerplate.support.RestDocsSupport;
@@ -86,6 +88,7 @@ class AuthControllerTest extends RestDocsSupport {
 								fieldWithPath("loginId").description("아이디는 영문 4자리 이상입니다.").type(JsonFieldType.STRING),
 								fieldWithPath("password").description("비밀번호는 특수문자를 포함한 영문과 숫자 8자리 이상입니다.").type(JsonFieldType.STRING)
 							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.responseHeaders(
 								headerWithName(HttpHeaders.AUTHORIZATION).description("엑세스 토큰입니다."),
 								headerWithName(HttpHeaders.SET_COOKIE).description("재발급 토큰 쿠키입니다.")
@@ -120,6 +123,7 @@ class AuthControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -152,6 +156,7 @@ class AuthControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -184,6 +189,7 @@ class AuthControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(AuthenticateUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -214,6 +220,7 @@ class AuthControllerTest extends RestDocsSupport {
 							.tag(BASE_TAG)
 							.summary("로그아웃")
 							.description("- 로그아웃 입니다. 브라우저 쿠키를 초기화 합니다.")
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.build()
 						)
 					)
@@ -253,6 +260,7 @@ class AuthControllerTest extends RestDocsSupport {
 								+ "- 재발급 시 새로운 엑세스 토큰을 헤더에 응답합니다.\n"
 								+ "- 401이 뜬다면, 재로그인이 필요합니다.\n"
 							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.responseHeaders(
 								headerWithName(HttpHeaders.AUTHORIZATION).description("새로운 엑세스 토큰입니다.")
 							)
@@ -280,6 +288,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -309,6 +318,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -338,6 +348,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);

--- a/src/test/java/com/hello/boilerplate/common/presentation/HealthCheckControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/common/presentation/HealthCheckControllerTest.java
@@ -2,7 +2,10 @@ package com.hello.boilerplate.common.presentation;
 
 import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.hello.boilerplate.common.presentation.dto.ApiResponse;
 import com.hello.boilerplate.support.RestDocsSupport;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -23,14 +26,13 @@ class HealthCheckControllerTest extends RestDocsSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
 			.andExpect(jsonPath("$.data").isEmpty())
-			.andDo(restDocsHandler.document(
-				ResourceDocumentation.resource(
-					ResourceSnippetParameters.builder()
-						.tag("🏠[Team Workspace]")
-						.summary("팀 협업을 위한 공용 정보")
-						.description(readMarkdown(TEAM_MD_PATH))
-						.build())
-                )
+			.andDo(restDocsHandler.document(ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+					.tag("🏠[Team Workspace]")
+					.summary("팀 협업을 위한 공용 정보")
+					.description(readMarkdown(TEAM_MD_PATH))
+					.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+					.build())
+				)
 			);
     }
 }

--- a/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -665,6 +667,9 @@ class UserControllerTest extends RestDocsSupport {
 								+ "- 서버의 권한 정보 및 클라이언트의 권한 쿠키를 초기화 합니다.\n"
 							)
 							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.responseHeaders(
+								headerWithName(HttpHeaders.SET_COOKIE).description("초기화 쿠키 입니다.")
+							)
 							.build())
 					)
 				);

--- a/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
@@ -4,6 +4,8 @@ import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.epages.restdocs.apispec.SimpleType;
+import com.hello.boilerplate.common.presentation.dto.ApiErrorResponse;
+import com.hello.boilerplate.common.presentation.dto.ApiResponse;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.presentation.dto.request.ChangePassword;
 import com.hello.boilerplate.user.presentation.dto.request.RegisterUser;
@@ -20,10 +22,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.headers.HeaderDocumentation;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
@@ -87,6 +87,7 @@ class UserControllerTest extends RestDocsSupport {
 							fieldWithPath("email").description("이메일 형식을 지켜주세요.").type(JsonFieldType.STRING),
 							fieldWithPath("name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
 						)
+						.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 						.build())
 				));
 		}
@@ -123,6 +124,7 @@ class UserControllerTest extends RestDocsSupport {
 					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 						.tag(BASE_TAG)
 						.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
+						.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 						.build())
 					)
 				);
@@ -160,6 +162,7 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -194,6 +197,7 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -230,7 +234,9 @@ class UserControllerTest extends RestDocsSupport {
 							+ "- 200응답이라면 사용 가능합니다."
 						)
 						.queryParameters(
-							parameterWithName("loginId").description("검증 대상 아이디").type(SimpleType.STRING))
+							parameterWithName("loginId").description("검증 대상 아이디").type(SimpleType.STRING)
+						)
+						.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 						.build())
 					)
 				);
@@ -260,6 +266,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -296,7 +303,9 @@ class UserControllerTest extends RestDocsSupport {
 								+ "- 200응답이라면 사용 가능합니다."
 							)
 							.queryParameters(
-								parameterWithName("email").description("검증 대상 이메일").type(SimpleType.STRING))
+								parameterWithName("email").description("검증 대상 이메일").type(SimpleType.STRING)
+							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -326,6 +335,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -437,6 +447,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -481,6 +492,7 @@ class UserControllerTest extends RestDocsSupport {
 							.requestFields(
 								fieldWithPath("name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
 							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.build()
 						)
 					)
@@ -511,6 +523,7 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(UpdateUser.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -553,6 +566,7 @@ class UserControllerTest extends RestDocsSupport {
 								fieldWithPath("password").description("기존 비밀번호입니다.").type(JsonFieldType.STRING),
 								fieldWithPath("newPassword").description("새로운 비밀번호입니다.").type(JsonFieldType.STRING)
 							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -585,6 +599,7 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(ChangePassword.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -615,6 +630,7 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.requestSchema(Schema.schema(ChangePassword.class.getSimpleName()))
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -648,6 +664,7 @@ class UserControllerTest extends RestDocsSupport {
 								+ "### 참고 \n"
 								+ "- 서버의 권한 정보 및 클라이언트의 권한 쿠키를 초기화 합니다.\n"
 							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
 							.build())
 					)
 				);

--- a/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/user/presentation/UserControllerTest.java
@@ -23,13 +23,14 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.headers.HeaderDocumentation;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -79,13 +80,13 @@ class UserControllerTest extends RestDocsSupport {
 							+ "- 필드의 validation을 확인해주세요.\n"
 							+ "- 아이디와 이메일 중복 체크 완료 후 진행해주세요."
 						)
-						.requestSchema(Schema.schema("RegisterUser"))
-							.requestFields(
-								fieldWithPath("loginId").description("아이디는 영문 4자리 이상입니다.").type(JsonFieldType.STRING),
-								fieldWithPath("password").description("비밀번호는 특수문자를 포함한 영문과 숫자 8자리 이상입니다.").type(JsonFieldType.STRING),
-								fieldWithPath("email").description("이메일 형식을 지켜주세요.").type(JsonFieldType.STRING),
-								fieldWithPath("name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
-							)
+						.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
+						.requestFields(
+							fieldWithPath("loginId").description("아이디는 영문 4자리 이상입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("password").description("비밀번호는 특수문자를 포함한 영문과 숫자 8자리 이상입니다.").type(JsonFieldType.STRING),
+							fieldWithPath("email").description("이메일 형식을 지켜주세요.").type(JsonFieldType.STRING),
+							fieldWithPath("name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
+						)
 						.build())
 				));
 		}
@@ -121,6 +122,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 					ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 						.tag(BASE_TAG)
+						.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
 						.build())
 					)
 				);
@@ -157,6 +159,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -190,6 +193,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(RegisterUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -226,7 +230,7 @@ class UserControllerTest extends RestDocsSupport {
 							+ "- 200응답이라면 사용 가능합니다."
 						)
 						.queryParameters(
-							ResourceDocumentation.parameterWithName("loginId").description("검증 대상 아이디").type(SimpleType.STRING))
+							parameterWithName("loginId").description("검증 대상 아이디").type(SimpleType.STRING))
 						.build())
 					)
 				);
@@ -292,7 +296,7 @@ class UserControllerTest extends RestDocsSupport {
 								+ "- 200응답이라면 사용 가능합니다."
 							)
 							.queryParameters(
-								ResourceDocumentation.parameterWithName("email").description("검증 대상 이메일").type(SimpleType.STRING))
+								parameterWithName("email").description("검증 대상 이메일").type(SimpleType.STRING))
 							.build())
 					)
 				);
@@ -354,6 +358,13 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.summary("프로필 조회")
+							.responseSchema(Schema.schema(ProfileInfo.class.getSimpleName()))
+							.responseFields(
+								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.loginId").description("사용자 아이디입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.email").description("사용자 이메일입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
+							)
 							.build())
 					)
 				);
@@ -386,7 +397,17 @@ class UserControllerTest extends RestDocsSupport {
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
 							.summary("공개 프로필 조회")
-							.build())
+							.pathParameters(
+								parameterWithName("userId").description("조회할 사용자의 PK입니다.")
+							)
+							.responseSchema(Schema.schema(PublicProfileInfo.class.getSimpleName()))
+							.responseFields(
+								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.email").description("사용자 이메일입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
+							)
+							.build()
+						)
 					)
 				);
 		}
@@ -456,11 +477,12 @@ class UserControllerTest extends RestDocsSupport {
 								+ "### 사용법 \n"
 								+ "- 필드의 validation을 확인해주세요.\n"
 							)
-							.requestSchema(Schema.schema("UpdateUser"))
+							.requestSchema(Schema.schema(UpdateUser.class.getSimpleName()))
 							.requestFields(
 								fieldWithPath("name").description("사용자 이름입니다.").type(JsonFieldType.STRING)
 							)
-							.build())
+							.build()
+						)
 					)
 				);
 		}
@@ -488,6 +510,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(UpdateUser.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -525,7 +548,7 @@ class UserControllerTest extends RestDocsSupport {
 								+ "### 사용법 \n"
 								+ "- 필드의 validation을 확인해주세요.\n"
 							)
-							.requestSchema(Schema.schema("ChangePassword"))
+							.requestSchema(Schema.schema(ChangePassword.class.getSimpleName()))
 							.requestFields(
 								fieldWithPath("password").description("기존 비밀번호입니다.").type(JsonFieldType.STRING),
 								fieldWithPath("newPassword").description("새로운 비밀번호입니다.").type(JsonFieldType.STRING)
@@ -561,6 +584,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(ChangePassword.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -590,6 +614,7 @@ class UserControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(ChangePassword.class.getSimpleName()))
 							.build())
 					)
 				);
@@ -607,7 +632,8 @@ class UserControllerTest extends RestDocsSupport {
 		    //when
 			ResultActions actions = mockMvc.perform(
 				delete(BASE_URI)
-					.contentType(MediaType.APPLICATION_JSON));
+					.contentType(MediaType.APPLICATION_JSON)
+			);
 
 		    //then
 			actions
@@ -621,9 +647,6 @@ class UserControllerTest extends RestDocsSupport {
 							.description("## 회원 탈퇴 기능 \n"
 								+ "### 참고 \n"
 								+ "- 서버의 권한 정보 및 클라이언트의 권한 쿠키를 초기화 합니다.\n"
-							)
-							.responseHeaders(
-								headerWithName(HttpHeaders.SET_COOKIE).description("쿠키 초기화입니다.")
 							)
 							.build())
 					)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#41 ](이슈 링크)

### 변경 사항
### 1. API 문서 업데이트 날짜
gradle 빌드 시간을 명시하여 API 문서의 업데이트 날짜를 명세하도록 했습니다.
프론트엔드 개발자는 언제 업데이트가 된 문서인지 확인할 수 있게되었습니다.

### 2. 분리된 yaml 통합
openapi3.yaml만 있는것이 아닌, 각 서버(모듈)별 yaml이 추가 될 수 있음을 가정했습니다.
우측 상단에서 yaml을 고를 수 있습니다.

### 3. 응답 스키마
응답 스키마를 설정했습니다.
프론트엔드 개발자는 응답 스키마를 확인할 수 있게 되었습니다.

### 테스트 결과
<img width="555" height="212" alt="스크린샷 2025-11-25 오후 10 04 23" src="https://github.com/user-attachments/assets/afa0a1d2-ed98-4eae-a59a-9d9e0e2035c1" />

<img width="1179" height="149" alt="스크린샷 2025-11-25 오후 10 39 10" src="https://github.com/user-attachments/assets/01d4ada4-2112-46e3-86fc-ecc07f41a911" />

<img width="633" height="660" alt="스크린샷 2025-11-25 오후 10 38 35" src="https://github.com/user-attachments/assets/28627b3d-9f3f-42aa-84e7-62a42400c843" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Swagger UI에서 여러 API 문서를 선택하여 조회 가능
  * API 응답 스키마 및 헤더 정보 상세 문서화

* **개선사항**
  * API 버전 정보가 실시간 타임스탬프 형식으로 자동 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->