### PR TITLE
[#49] 아이디 비밀번호 찾기 기능

### DIFF
--- a/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
@@ -1,0 +1,61 @@
+package com.hello.boilerplate.auth.application;
+
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Service;
+
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
+import com.hello.boilerplate.user.domain.User;
+import com.hello.boilerplate.user.domain.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AccountRecoveryService {
+
+	private static final String RETRIEVE_LOGIN_ID_MAIL_SUBJECT = "아이디 확인 메일";
+	private static final String RETRIEVE_LOGIN_ID_MAIL = "mail/auth/retrieve-login-id";
+	private static final String RETRIEVE_PASSWORD_MAIL_SUBJECT = "인증번호 발송 메일";
+	private static final String RETRIEVE_PASSWORD_MAIL = "mail/auth/retrieve-password";
+
+	private final UserRepository userRepository;
+	private final MailSender mailSender;
+	private final TemplateRenderer templateRenderer;
+	private final VerificationCodeStore verificationCodeStore;
+
+	public void retrieveLoginId(FindLoginId findLoginId) {
+		User user = userRepository.findUserByEmail(findLoginId.email())
+			.orElseThrow(() -> new NotFoundException(User.class));
+
+		String mailContent = templateRenderer.render(RETRIEVE_LOGIN_ID_MAIL,
+			Map.of(
+				"name", user.getName(),
+				"loginId", user.getLoginId()
+			)
+		);
+		mailSender.send(user.getEmail(), RETRIEVE_LOGIN_ID_MAIL_SUBJECT, mailContent);
+	}
+
+	public void retrievePassword(FindPassword findPassword) {
+		User user = userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email())
+			.orElseThrow(() -> new NotFoundException(User.class));
+
+		String code = generateCode();
+		verificationCodeStore.save(VerificationCodeType.PASSWORD_RESET, user.getLoginId(), code);
+		String mailContent = templateRenderer.render(RETRIEVE_PASSWORD_MAIL, Map.of("code", code));
+
+		mailSender.send(user.getEmail(), RETRIEVE_PASSWORD_MAIL_SUBJECT, mailContent);
+	}
+
+	private String generateCode() {
+		int number = ThreadLocalRandom.current().nextInt(100_000, 1_000_000);
+		return String.valueOf(number);
+	}
+}

--- a/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
@@ -1,13 +1,19 @@
 package com.hello.boilerplate.auth.application;
 
+import java.util.Date;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
+import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
+import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
@@ -19,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AccountRecoveryService {
+	private static final String VERIFY_CODE_ERROR_MESSAGE = "인증번호가 올바르지 않습니다.";
 
 	private static final String RETRIEVE_LOGIN_ID_MAIL_SUBJECT = "아이디 확인 메일";
 	private static final String RETRIEVE_LOGIN_ID_MAIL = "mail/auth/retrieve-login-id";
@@ -29,6 +36,7 @@ public class AccountRecoveryService {
 	private final MailSender mailSender;
 	private final TemplateRenderer templateRenderer;
 	private final VerificationCodeStore verificationCodeStore;
+	private final JwtUtil jwtUtil;
 
 	public void retrieveLoginId(FindLoginId findLoginId) {
 		User user = userRepository.findUserByEmail(findLoginId.email())
@@ -48,7 +56,7 @@ public class AccountRecoveryService {
 			.orElseThrow(() -> new NotFoundException(User.class));
 
 		String code = generateCode();
-		verificationCodeStore.save(VerificationCodeType.PASSWORD_RESET, user.getLoginId(), code);
+		verificationCodeStore.save(VerificationPurpose.PASSWORD_RESET, user.getLoginId(), code);
 		String mailContent = templateRenderer.render(RETRIEVE_PASSWORD_MAIL, Map.of("code", code));
 
 		mailSender.send(user.getEmail(), RETRIEVE_PASSWORD_MAIL_SUBJECT, mailContent);
@@ -57,5 +65,19 @@ public class AccountRecoveryService {
 	private String generateCode() {
 		int number = ThreadLocalRandom.current().nextInt(100_000, 1_000_000);
 		return String.valueOf(number);
+	}
+
+	public PasswordCodeVerified verifyCode(VerifyPasswordCode verifyPasswordCode) {
+		String loginId = verifyPasswordCode.loginId();
+		String storeCode = verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, loginId);
+
+		if (!storeCode.equals(verifyPasswordCode.code())) {
+			throw new CustomException(HttpStatus.BAD_REQUEST, VERIFY_CODE_ERROR_MESSAGE);
+		}
+		verificationCodeStore.delete(VerificationPurpose.PASSWORD_RESET, loginId);
+
+		return new PasswordCodeVerified(
+			jwtUtil.createVerificationToken(VerificationPurpose.PASSWORD_RESET, loginId, new Date())
+		);
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/AccountRecoveryService.java
@@ -5,16 +5,21 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.ResetPassword;
 import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
 import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.exception.UnauthorizedException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.user.domain.User;
@@ -37,6 +42,7 @@ public class AccountRecoveryService {
 	private final TemplateRenderer templateRenderer;
 	private final VerificationCodeStore verificationCodeStore;
 	private final JwtUtil jwtUtil;
+	private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
 	public void retrieveLoginId(FindLoginId findLoginId) {
 		User user = userRepository.findUserByEmail(findLoginId.email())
@@ -79,5 +85,16 @@ public class AccountRecoveryService {
 		return new PasswordCodeVerified(
 			jwtUtil.createVerificationToken(VerificationPurpose.PASSWORD_RESET, loginId, new Date())
 		);
+	}
+
+	@Transactional
+	public void resetPasswordByVerificationToken(ResetPassword resetPassword) {
+		String loginId = jwtUtil.getVerificationToken(
+			VerificationPurpose.PASSWORD_RESET, resetPassword.token()
+		).getSubject();
+
+		User user = userRepository.findUserByLoginId(loginId)
+			.orElseThrow(() -> new UnauthorizedException(AuthorizationErrorMessages.AUTH_USER_NOT_FOUND));
+		user.updatePassword(bCryptPasswordEncoder.encode(resetPassword.password()));
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/application/AuthService.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/AuthService.java
@@ -1,10 +1,14 @@
 package com.hello.boilerplate.auth.application;
 
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
+import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
 import com.hello.boilerplate.common.exception.CustomException;
@@ -16,18 +20,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
-
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
 	private final static String MATCH_ERROR_MESSAGE = "아이디 혹은 비밀번호가 일치하지 않습니다.";
+	private static final String RETRIEVE_LOGIN_ID_MAIL_SUBJECT = "아이디 확인 메일";
+	private static final String RETRIEVE_LOGIN_ID_MAIL = "mail/auth/retrieve-login-id";
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 	private final RefreshTokenStore refreshTokenStore;
     private final JwtUtil jwtUtil;
+	private final MailSender mailSender;
+	private final TemplateRenderer templateRenderer;
 
     public AuthenticationResult authenticate(AuthenticateUser authenticateUser) {
         User user = userRepository.findUserByLoginId(authenticateUser.loginId())
@@ -65,5 +73,18 @@ public class AuthService {
 			refreshTokenStore.delete(subject);
 			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
 		}
+	}
+
+	public void retrieveLoginId(FindLoginId findLoginId) {
+		User user = userRepository.findUserByEmail(findLoginId.email())
+			.orElseThrow(() -> new NotFoundException(User.class));
+
+		String mailContent = templateRenderer.render(RETRIEVE_LOGIN_ID_MAIL,
+			Map.of(
+				"name", user.getName(),
+				"loginId", user.getLoginId()
+			)
+		);
+		mailSender.send(user.getEmail(), RETRIEVE_LOGIN_ID_MAIL_SUBJECT, mailContent);
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/application/AuthService.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/AuthService.java
@@ -1,14 +1,10 @@
 package com.hello.boilerplate.auth.application;
 
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
-import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
-import com.hello.boilerplate.common.exception.NotFoundException;
-import com.hello.boilerplate.common.infrastructure.mail.MailSender;
-import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
 import com.hello.boilerplate.common.exception.CustomException;
@@ -20,22 +16,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
+
 	private final static String MATCH_ERROR_MESSAGE = "아이디 혹은 비밀번호가 일치하지 않습니다.";
-	private static final String RETRIEVE_LOGIN_ID_MAIL_SUBJECT = "아이디 확인 메일";
-	private static final String RETRIEVE_LOGIN_ID_MAIL = "mail/auth/retrieve-login-id";
 
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 	private final RefreshTokenStore refreshTokenStore;
     private final JwtUtil jwtUtil;
-	private final MailSender mailSender;
-	private final TemplateRenderer templateRenderer;
 
     public AuthenticationResult authenticate(AuthenticateUser authenticateUser) {
         User user = userRepository.findUserByLoginId(authenticateUser.loginId())
@@ -73,18 +65,5 @@ public class AuthService {
 			refreshTokenStore.delete(subject);
 			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
 		}
-	}
-
-	public void retrieveLoginId(FindLoginId findLoginId) {
-		User user = userRepository.findUserByEmail(findLoginId.email())
-			.orElseThrow(() -> new NotFoundException(User.class));
-
-		String mailContent = templateRenderer.render(RETRIEVE_LOGIN_ID_MAIL,
-			Map.of(
-				"name", user.getName(),
-				"loginId", user.getLoginId()
-			)
-		);
-		mailSender.send(user.getEmail(), RETRIEVE_LOGIN_ID_MAIL_SUBJECT, mailContent);
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/application/VerificationCodeStore.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/VerificationCodeStore.java
@@ -1,0 +1,9 @@
+package com.hello.boilerplate.auth.application;
+
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+
+public interface VerificationCodeStore {
+	void save(VerificationCodeType type, String key, String code);
+	String get(VerificationCodeType type, String key);
+	void delete(VerificationCodeType type, String key);
+}

--- a/src/main/java/com/hello/boilerplate/auth/application/VerificationCodeStore.java
+++ b/src/main/java/com/hello/boilerplate/auth/application/VerificationCodeStore.java
@@ -1,9 +1,9 @@
 package com.hello.boilerplate.auth.application;
 
-import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 
 public interface VerificationCodeStore {
-	void save(VerificationCodeType type, String key, String code);
-	String get(VerificationCodeType type, String key);
-	void delete(VerificationCodeType type, String key);
+	void save(VerificationPurpose purpose, String key, String code);
+	String get(VerificationPurpose purpose, String key);
+	void delete(VerificationPurpose purpose, String key);
 }

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/RedisRefreshTokenStore.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/RedisRefreshTokenStore.java
@@ -12,28 +12,28 @@ import com.hello.boilerplate.auth.application.RefreshTokenStore;
 public class RedisRefreshTokenStore implements RefreshTokenStore {
 
 	private final long expirationSeconds;
-    private final RedisTemplate<String, String> tokenRedisTemplate;
+    private final RedisTemplate<String, String> stringRedisTemplate;
 
 	public RedisRefreshTokenStore(
-		RedisTemplate<String, String> tokenRedisTemplate,
+		RedisTemplate<String, String> stringRedisTemplate,
 		@Value("${jwt.refresh-token-valid-days}") Long expirationDays
 	) {
-		this.tokenRedisTemplate = tokenRedisTemplate;
+		this.stringRedisTemplate = stringRedisTemplate;
 		this.expirationSeconds = expirationDays * 24 * 60 * 60;
 	}
 
 	@Override
     public void save(String subject, String token) {
-        tokenRedisTemplate.opsForValue().set(KEY_PREFIX + subject, token, expirationSeconds, TimeUnit.SECONDS);
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + subject, token, expirationSeconds, TimeUnit.SECONDS);
     }
 
 	@Override
     public String get(String subject) {
-        return tokenRedisTemplate.opsForValue().get(KEY_PREFIX + subject);
+        return stringRedisTemplate.opsForValue().get(KEY_PREFIX + subject);
     }
 
 	@Override
     public void delete(String subject) {
-        tokenRedisTemplate.delete(KEY_PREFIX + subject);
+        stringRedisTemplate.delete(KEY_PREFIX + subject);
     }
 }

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtConstants.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtConstants.java
@@ -1,6 +1,7 @@
 package com.hello.boilerplate.auth.infrastructure.jwt;
 
 public class JwtConstants {
-    public static final String AUTHORITIES_KEY = "role";
+    public static final String AUTHORITIES_CLAIM_KEY = "role";
+	public static final String VERIFICATION_CLAIM_KEY = "purpose";
 	public static final String BEARER_PREFIX = "Bearer ";
 }

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
@@ -27,7 +27,7 @@ public class JwtUtil {
     public JwtUtil(
 		@Value("${jwt.access-secret-key}") String accessTokenSecret,
 		@Value("${jwt.refresh-secret-key}") String refreshTokenSecret,
-		@Value("${jwt.refresh-secret-key}") String verifyTokenSecretKey,
+		@Value("${jwt.verification-secret-key}") String verifyTokenSecretKey,
 		@Value("${jwt.access-token-valid-days}") Long accessTokenExpirationDays,
 		@Value("${jwt.refresh-token-valid-days}") Long refreshTokenExpirationDays
 	) {

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.hello.boilerplate.auth.infrastructure.jwt;
 
 import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
 import io.jsonwebtoken.*;
@@ -15,19 +16,24 @@ import java.util.Date;
 @Component
 public class JwtUtil {
 	private static final long MILLIS_PER_SECOND = 1_000L;
+	private static final long VERIFICATION_TOKEN_EXPIRATION_SECONDS = 60L * 10;
 
     private final SecretKey accessTokenSigningKey;
     private final SecretKey refreshTokenSigningKey;
+	private final SecretKey verifyTokenSigningKey;
     private final long accessTokenExpirationSeconds;
     private final long refreshTokenExpirationSeconds;
 
     public JwtUtil(
-            @Value("${jwt.access-secret-key}") String accessTokenSecret,
-            @Value("${jwt.refresh-secret-key}") String refreshTokenSecret,
-            @Value("${jwt.access-token-valid-days}") Long accessTokenExpirationDays,
-            @Value("${jwt.refresh-token-valid-days}") Long refreshTokenExpirationDays) {
+		@Value("${jwt.access-secret-key}") String accessTokenSecret,
+		@Value("${jwt.refresh-secret-key}") String refreshTokenSecret,
+		@Value("${jwt.refresh-secret-key}") String verifyTokenSecretKey,
+		@Value("${jwt.access-token-valid-days}") Long accessTokenExpirationDays,
+		@Value("${jwt.refresh-token-valid-days}") Long refreshTokenExpirationDays
+	) {
         this.accessTokenSigningKey = Keys.hmacShaKeyFor(accessTokenSecret.getBytes(StandardCharsets.UTF_8));
         this.refreshTokenSigningKey = Keys.hmacShaKeyFor(refreshTokenSecret.getBytes(StandardCharsets.UTF_8));
+		this.verifyTokenSigningKey = Keys.hmacShaKeyFor(verifyTokenSecretKey.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpirationSeconds = accessTokenExpirationDays * 24 * 60 * 60;
         this.refreshTokenExpirationSeconds = refreshTokenExpirationDays * 24 * 60 * 60;
     }
@@ -35,7 +41,7 @@ public class JwtUtil {
     public String createAccessToken(User user, Date now) {
         return Jwts.builder()
                 .subject(user.getLoginId())
-                .claim(JwtConstants.AUTHORITIES_KEY, user.getRole().getKey())
+                .claim(JwtConstants.AUTHORITIES_CLAIM_KEY, user.getRole().getKey())
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + accessTokenExpirationSeconds * MILLIS_PER_SECOND))
                 .signWith(accessTokenSigningKey)
@@ -50,6 +56,16 @@ public class JwtUtil {
                 .signWith(refreshTokenSigningKey)
                 .compact();
     }
+
+	public String createVerificationToken(VerificationPurpose purpose, String loginId, Date now) {
+		return Jwts.builder()
+			.subject(loginId)
+			.claim(JwtConstants.VERIFICATION_CLAIM_KEY, purpose.name())
+			.issuedAt(now)
+			.expiration(new Date(now.getTime() + VERIFICATION_TOKEN_EXPIRATION_SECONDS * MILLIS_PER_SECOND))
+			.signWith(verifyTokenSigningKey)
+			.compact();
+	}
 
     public Claims getAccessTokenClaims(String token) {
         try {
@@ -85,7 +101,7 @@ public class JwtUtil {
 
 	private void validateAccessTokenClaims(Claims claims) {
 		String subject = claims.getSubject();
-		Object role = claims.get(JwtConstants.AUTHORITIES_KEY);
+		Object role = claims.get(JwtConstants.AUTHORITIES_CLAIM_KEY);
 
 		if (subject == null || role == null) {
 			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtil.java
@@ -99,9 +99,25 @@ public class JwtUtil {
 		}
 	}
 
+	public Claims getVerificationToken(VerificationPurpose purpose, String token) {
+		try {
+			Claims claims = Jwts.parser()
+				.verifyWith(verifyTokenSigningKey)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+
+			validateVerificationTokenClaims(purpose, claims);
+			return claims;
+
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
+		}
+	}
+
 	private void validateAccessTokenClaims(Claims claims) {
 		String subject = claims.getSubject();
-		Object role = claims.get(JwtConstants.AUTHORITIES_CLAIM_KEY);
+		String role = claims.get(JwtConstants.AUTHORITIES_CLAIM_KEY, String.class);
 
 		if (subject == null || role == null) {
 			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
@@ -111,6 +127,15 @@ public class JwtUtil {
 	private void validateRefreshTokenClaims(Claims claims) {
 		String subject = claims.getSubject();
 		if (subject == null) {
+			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
+		}
+	}
+
+	private void validateVerificationTokenClaims(VerificationPurpose requiredPurpose, Claims claims) {
+		String subject = claims.getSubject();
+		String purpose = claims.get(JwtConstants.VERIFICATION_CLAIM_KEY, String.class);
+
+		if (subject == null || !requiredPurpose.name().equals(purpose)) {
 			throw new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION);
 		}
 	}

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/security/JwtAuthorizationFilter.java
@@ -66,7 +66,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 claims.getSubject(),
                 null,
-                List.of(new SimpleGrantedAuthority(claims.get(JwtConstants.AUTHORITIES_KEY).toString()))
+                List.of(new SimpleGrantedAuthority(claims.get(JwtConstants.AUTHORITIES_CLAIM_KEY).toString()))
         );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStore.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStore.java
@@ -1,0 +1,40 @@
+package com.hello.boilerplate.auth.infrastructure.verification;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.hello.boilerplate.auth.application.VerificationCodeStore;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisVerificationCodeStore implements VerificationCodeStore {
+
+	private static final String KEY_PREFIX = "code:";
+	private static final Long DEFAULT_TTL_SECONDS = 60L * 5;
+
+	private final RedisTemplate<String, String> stringRedisTemplate;
+
+	@Override
+	public void save(VerificationCodeType type, String key, String code) {
+		String redisKey = createKey(type, key);
+		stringRedisTemplate.opsForValue().set(redisKey, code, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
+	}
+
+	@Override
+	public String get(VerificationCodeType type, String key) {
+		return stringRedisTemplate.opsForValue().get(createKey(type, key));
+	}
+
+	@Override
+	public void delete(VerificationCodeType type, String key) {
+		stringRedisTemplate.delete(createKey(type, key));
+	}
+
+	private String createKey(VerificationCodeType type, String key) {
+		return KEY_PREFIX + type.name().toLowerCase() + ":" + key;
+	}
+}

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStore.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStore.java
@@ -19,22 +19,22 @@ public class RedisVerificationCodeStore implements VerificationCodeStore {
 	private final RedisTemplate<String, String> stringRedisTemplate;
 
 	@Override
-	public void save(VerificationCodeType type, String key, String code) {
-		String redisKey = createKey(type, key);
+	public void save(VerificationPurpose purpose, String key, String code) {
+		String redisKey = createKey(purpose, key);
 		stringRedisTemplate.opsForValue().set(redisKey, code, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
 	}
 
 	@Override
-	public String get(VerificationCodeType type, String key) {
-		return stringRedisTemplate.opsForValue().get(createKey(type, key));
+	public String get(VerificationPurpose purpose, String key) {
+		return stringRedisTemplate.opsForValue().get(createKey(purpose, key));
 	}
 
 	@Override
-	public void delete(VerificationCodeType type, String key) {
-		stringRedisTemplate.delete(createKey(type, key));
+	public void delete(VerificationPurpose purpose, String key) {
+		stringRedisTemplate.delete(createKey(purpose, key));
 	}
 
-	private String createKey(VerificationCodeType type, String key) {
-		return KEY_PREFIX + type.name().toLowerCase() + ":" + key;
+	private String createKey(VerificationPurpose purpose, String key) {
+		return KEY_PREFIX + purpose.name().toLowerCase() + ":" + key;
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/VerificationCodeType.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/VerificationCodeType.java
@@ -1,0 +1,5 @@
+package com.hello.boilerplate.auth.infrastructure.verification;
+
+public enum VerificationCodeType {
+	PASSWORD_RESET
+}

--- a/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/VerificationPurpose.java
+++ b/src/main/java/com/hello/boilerplate/auth/infrastructure/verification/VerificationPurpose.java
@@ -1,5 +1,5 @@
 package com.hello.boilerplate.auth.infrastructure.verification;
 
-public enum VerificationCodeType {
+public enum VerificationPurpose {
 	PASSWORD_RESET
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpHeaders.*;
 import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.application.AuthService;
@@ -78,6 +79,12 @@ public class AuthController {
 	@PostMapping("/id/find")
 	public ResponseEntity<ApiResponse<Void>> retrieveLoginId(@RequestBody @Valid FindLoginId findLoginId) {
 		accountRecoveryService.retrieveLoginId(findLoginId);
+		return ResponseEntity.ok().body(ApiResponse.of());
+	}
+
+	@PostMapping("/password/find")
+	public ResponseEntity<ApiResponse<Void>> retrievePassword(@RequestBody @Valid FindPassword findPassword) {
+		accountRecoveryService.retrievePassword(findPassword);
 		return ResponseEntity.ok().body(ApiResponse.of());
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -7,6 +7,7 @@ import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.application.AuthService;
@@ -86,5 +87,10 @@ public class AuthController {
 	public ResponseEntity<ApiResponse<Void>> retrievePassword(@RequestBody @Valid FindPassword findPassword) {
 		accountRecoveryService.retrievePassword(findPassword);
 		return ResponseEntity.ok().body(ApiResponse.of());
+	}
+
+	@PostMapping("/password/verify")
+	public ResponseEntity<?> verifyCode(@RequestBody @Valid VerifyPasswordCode verifyPasswordCode) {
+		return ResponseEntity.ok().body(ApiResponse.of(accountRecoveryService.verifyCode(verifyPasswordCode)));
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -4,6 +4,7 @@ import static com.hello.boilerplate.auth.infrastructure.jwt.JwtConstants.*;
 import static org.springframework.http.HttpHeaders.*;
 
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.application.AuthService;
@@ -71,4 +72,10 @@ public class AuthController {
                 .header(AUTHORIZATION, BEARER_PREFIX + reissuedToken.accessToken())
                 .body(ApiResponse.of());
     }
+
+	@PostMapping("/find-id")
+	public ResponseEntity<ApiResponse<Void>> retrieveLoginId(@RequestBody @Valid FindLoginId findLoginId) {
+		authService.retrieveLoginId(findLoginId);
+		return ResponseEntity.ok().body(ApiResponse.of());
+	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.hello.boilerplate.auth.presentation;
 import static com.hello.boilerplate.auth.infrastructure.jwt.JwtConstants.*;
 import static org.springframework.http.HttpHeaders.*;
 
+import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
@@ -34,6 +35,7 @@ public class AuthController {
 	private String REFRESH_TOKEN_COOKIE_NAME;
 
     private final AuthService authService;
+	private final AccountRecoveryService accountRecoveryService;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> authenticate(@RequestBody @Valid AuthenticateUser authenticateUser) {
@@ -75,7 +77,7 @@ public class AuthController {
 
 	@PostMapping("/find-id")
 	public ResponseEntity<ApiResponse<Void>> retrieveLoginId(@RequestBody @Valid FindLoginId findLoginId) {
-		authService.retrieveLoginId(findLoginId);
+		accountRecoveryService.retrieveLoginId(findLoginId);
 		return ResponseEntity.ok().body(ApiResponse.of());
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -7,8 +7,10 @@ import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.ResetPassword;
 import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
+import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.application.AuthService;
 import com.hello.boilerplate.user.domain.User;
@@ -90,7 +92,13 @@ public class AuthController {
 	}
 
 	@PostMapping("/password/verify")
-	public ResponseEntity<?> verifyCode(@RequestBody @Valid VerifyPasswordCode verifyPasswordCode) {
+	public ResponseEntity<ApiResponse<PasswordCodeVerified>> verifyCode(@RequestBody @Valid VerifyPasswordCode verifyPasswordCode) {
 		return ResponseEntity.ok().body(ApiResponse.of(accountRecoveryService.verifyCode(verifyPasswordCode)));
+	}
+
+	@PostMapping("/password/reset")
+	public ResponseEntity<ApiResponse<Void>> passwordReset(@RequestBody @Valid ResetPassword resetPassword) {
+		accountRecoveryService.resetPasswordByVerificationToken(resetPassword);
+		return ResponseEntity.ok().body(ApiResponse.of());
 	}
 }

--- a/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/AuthController.java
@@ -75,7 +75,7 @@ public class AuthController {
                 .body(ApiResponse.of());
     }
 
-	@PostMapping("/find-id")
+	@PostMapping("/id/find")
 	public ResponseEntity<ApiResponse<Void>> retrieveLoginId(@RequestBody @Valid FindLoginId findLoginId) {
 		accountRecoveryService.retrieveLoginId(findLoginId);
 		return ResponseEntity.ok().body(ApiResponse.of());

--- a/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/FindLoginId.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/FindLoginId.java
@@ -1,0 +1,8 @@
+package com.hello.boilerplate.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+
+public record FindLoginId(
+	@Email String email
+) {
+}

--- a/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/FindPassword.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/FindPassword.java
@@ -1,0 +1,14 @@
+package com.hello.boilerplate.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record FindPassword(
+	@NotBlank
+	@Pattern(regexp = "^[A-Za-z0-9]{4,20}$")
+	String loginId,
+	@Email
+	String email
+) {
+}

--- a/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/ResetPassword.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/ResetPassword.java
@@ -1,0 +1,13 @@
+package com.hello.boilerplate.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ResetPassword(
+	@NotBlank
+	String token,
+	@NotBlank
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*?_~])[A-Za-z\\d!@#$%^&*?_~]{8,16}$")
+	String password
+) {
+}

--- a/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/VerifyPasswordCode.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/dto/request/VerifyPasswordCode.java
@@ -1,0 +1,13 @@
+package com.hello.boilerplate.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyPasswordCode(
+	@NotBlank
+	@Pattern(regexp = "^[A-Za-z0-9]{4,20}$")
+	String loginId,
+	@NotBlank
+	String code
+) {
+}

--- a/src/main/java/com/hello/boilerplate/auth/presentation/dto/response/PasswordCodeVerified.java
+++ b/src/main/java/com/hello/boilerplate/auth/presentation/dto/response/PasswordCodeVerified.java
@@ -1,0 +1,6 @@
+package com.hello.boilerplate.auth.presentation.dto.response;
+
+public record PasswordCodeVerified(
+	String token
+) {
+}

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/RedisConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/RedisConfig.java
@@ -20,7 +20,7 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> tokenRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    public RedisTemplate<String, String> StringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory);

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
 					.requestMatchers(
 						mvc.matcher(POST, AUTH_URI + "/login"),
 						mvc.matcher(POST, AUTH_URI + "/reissue"),
-						mvc.matcher(POST, AUTH_URI + "/find-id")
+						mvc.matcher(POST, AUTH_URI + "/id/find")
 					).permitAll()
 
 					//== 인증 필요 ==//

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
@@ -71,7 +71,8 @@ public class SecurityConfig {
 						mvc.matcher(POST, AUTH_URI + "/reissue"),
 						mvc.matcher(POST, AUTH_URI + "/id/find"),
 						mvc.matcher(POST, AUTH_URI + "/password/find"),
-						mvc.matcher(POST, AUTH_URI + "/password/verify")
+						mvc.matcher(POST, AUTH_URI + "/password/verify"),
+						mvc.matcher(POST, AUTH_URI + "/password/reset")
 					).permitAll()
 
 					//== 인증 필요 ==//

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
@@ -69,7 +69,8 @@ public class SecurityConfig {
 					.requestMatchers(
 						mvc.matcher(POST, AUTH_URI + "/login"),
 						mvc.matcher(POST, AUTH_URI + "/reissue"),
-						mvc.matcher(POST, AUTH_URI + "/id/find")
+						mvc.matcher(POST, AUTH_URI + "/id/find"),
+						mvc.matcher(POST, AUTH_URI + "/password/find")
 					).permitAll()
 
 					//== 인증 필요 ==//

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
@@ -70,7 +70,8 @@ public class SecurityConfig {
 						mvc.matcher(POST, AUTH_URI + "/login"),
 						mvc.matcher(POST, AUTH_URI + "/reissue"),
 						mvc.matcher(POST, AUTH_URI + "/id/find"),
-						mvc.matcher(POST, AUTH_URI + "/password/find")
+						mvc.matcher(POST, AUTH_URI + "/password/find"),
+						mvc.matcher(POST, AUTH_URI + "/password/verify")
 					).permitAll()
 
 					//== 인증 필요 ==//

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/config/SecurityConfig.java
@@ -68,7 +68,8 @@ public class SecurityConfig {
 
 					.requestMatchers(
 						mvc.matcher(POST, AUTH_URI + "/login"),
-						mvc.matcher(POST, AUTH_URI + "/reissue")
+						mvc.matcher(POST, AUTH_URI + "/reissue"),
+						mvc.matcher(POST, AUTH_URI + "/find-id")
 					).permitAll()
 
 					//== 인증 필요 ==//

--- a/src/main/java/com/hello/boilerplate/common/infrastructure/mail/SmtpMailSender.java
+++ b/src/main/java/com/hello/boilerplate/common/infrastructure/mail/SmtpMailSender.java
@@ -5,6 +5,7 @@ import java.io.UnsupportedEncodingException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import jakarta.mail.MessagingException;
@@ -23,6 +24,7 @@ public class SmtpMailSender implements MailSender {
 
 	private final JavaMailSender javaMailSender;
 
+	@Async("asyncThreadPool")
 	@Override
 	public void send(String recipientAddress, String mailSubject, String mailContent) {
 		MimeMessage message = javaMailSender.createMimeMessage();

--- a/src/main/java/com/hello/boilerplate/user/domain/UserRepository.java
+++ b/src/main/java/com/hello/boilerplate/user/domain/UserRepository.java
@@ -8,6 +8,7 @@ public interface UserRepository {
 	void delete(User user);
 
     Optional<User> findUserByLoginId(String loginId);
+	Optional<User> findUserByEmail(String email);
 	boolean existsByLoginId(String loginId);
 	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hello/boilerplate/user/domain/UserRepository.java
+++ b/src/main/java/com/hello/boilerplate/user/domain/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository {
 	Optional<User> findUserByEmail(String email);
 	boolean existsByLoginId(String loginId);
 	boolean existsByEmail(String email);
+	Optional<User> findUserByLoginIdAndEmail(String loginId, String email);
 }

--- a/src/main/java/com/hello/boilerplate/user/infrastructure/event/UserRegisteredEventHandler.java
+++ b/src/main/java/com/hello/boilerplate/user/infrastructure/event/UserRegisteredEventHandler.java
@@ -8,7 +8,6 @@ import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -23,7 +22,6 @@ public class UserRegisteredEventHandler {
 	private final TemplateRenderer templateRenderer;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Async("asyncThreadPool")
     public void onUserRegistered(UserRegisteredEvent event) {
 		String emailContent = templateRenderer
 			.render(WELCOME_MAIL, Map.of("name", event.user().getName()));

--- a/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserJpaRepository.java
@@ -9,6 +9,7 @@ import com.hello.boilerplate.user.domain.User;
 public interface UserJpaRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findUserByLoginId(String loginId);
+	Optional<User> findUserByEmail(String email);
 	boolean existsByLoginId(String loginId);
 	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserJpaRepository.java
+++ b/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserJpaRepository.java
@@ -12,4 +12,5 @@ public interface UserJpaRepository extends JpaRepository<User, Long> {
 	Optional<User> findUserByEmail(String email);
 	boolean existsByLoginId(String loginId);
 	boolean existsByEmail(String email);
+	Optional<User> findUserByLoginIdAndEmail(String loginId, String email);
 }

--- a/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -36,6 +36,11 @@ public class UserRepositoryImpl implements UserRepository {
 	}
 
 	@Override
+	public Optional<User> findUserByEmail(String email) {
+		return userJpaRepository.findUserByEmail(email);
+	}
+
+	@Override
 	public boolean existsByLoginId(String loginId) {
 		return userJpaRepository.existsByLoginId(loginId);
 	}

--- a/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserRepositoryImpl.java
+++ b/src/main/java/com/hello/boilerplate/user/infrastructure/persistence/UserRepositoryImpl.java
@@ -49,4 +49,9 @@ public class UserRepositoryImpl implements UserRepository {
 	public boolean existsByEmail(String email) {
 		return userJpaRepository.existsByEmail(email);
 	}
+
+	@Override
+	public Optional<User> findUserByLoginIdAndEmail(String loginId, String email) {
+		return userJpaRepository.findUserByLoginIdAndEmail(loginId, email);
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,7 @@ spring:
 jwt:
   access-secret-key: ${ACCESS_SECRET_KEY}
   refresh-secret-key: ${REFRESH_SECRET_KEY}
+  verification-secret-key: ${VERIFICATION_SECRET_KEY}
   access-token-valid-days: 3
   refresh-token-valid-days: 30
 
@@ -90,6 +91,7 @@ spring:
 jwt:
   access-secret-key: ${ACCESS_SECRET_KEY}
   refresh-secret-key: ${REFRESH_SECRET_KEY}
+  verification-secret-key: ${VERIFICATION_SECRET_KEY}
   access-token-valid-days: 3
   refresh-token-valid-days: 30
 
@@ -145,6 +147,7 @@ spring:
 jwt:
   access-secret-key: accessabcdefghijklmnopqrstuvwxyz
   refresh-secret-key: refreshabcdefghijklmnopqrstuvwxyz
+  verification-secret-key: verificationabcdefghijklmnopqrstu
   access-token-valid-days: 3
   refresh-token-valid-days: 30
 

--- a/src/main/resources/templates/mail/auth/retrieve-login-id.html
+++ b/src/main/resources/templates/mail/auth/retrieve-login-id.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>보일러플레이트 - 아이디 안내</title>
+</head>
+
+<body style="margin:0; padding:0; background-color:#f6f6f6; font-family:Arial, sans-serif;">
+
+<!-- 전체 wrapper -->
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f6f6f6; padding: 30px 0;">
+    <tr>
+        <td align="center">
+
+            <!-- 카드 영역 -->
+            <table width="600" cellpadding="0" cellspacing="0"
+                   style="background:#ffffff; border-radius:8px; padding:40px;">
+
+                <!-- 타이틀 -->
+                <tr>
+                    <td align="center" style="padding-bottom: 20px;">
+                        <h1 style="margin:0; font-size:28px; color:#333333; font-weight:bold;">
+                            보일러플레이트
+                        </h1>
+                    </td>
+                </tr>
+
+                <!-- 내용 -->
+                <tr>
+                    <td style="font-size:16px; color:#333333; line-height:1.6; text-align:center;">
+
+                        <p style="margin:20px 0;">
+                            <strong th:text="${name}">유저명</strong>님께서 요청하신
+                            <br/>
+                            아이디 정보를 안내드립니다.
+                        </p>
+
+                        <p style="margin:20px 0;">
+                            보일러플레이트 서비스에 가입하실 때 사용하신 아이디는 다음과 같습니다.
+                        </p>
+
+                        <!-- 아이디 박스 -->
+                        <table align="center" cellpadding="0" cellspacing="0" style="margin: 20px auto;">
+                            <tr>
+                                <td style="
+                                    padding: 12px 20px;
+                                    border-radius: 6px;
+                                    background-color:#f5f5f5;
+                                    font-size:18px;
+                                    font-weight:bold;
+                                    color:#333333;
+                                ">
+                                    <!-- 로그인 아이디 -->
+                                    <span th:text="${loginId}">exampleId</span>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <p style="margin:20px 0; font-size:14px; color:#666666;">
+                            만약 본인이 요청하지 않은 메일이라면,<br/>
+                            계정 보안을 위해 비밀번호 변경을 진행해 주시길 권장드립니다.
+                        </p>
+                    </td>
+                </tr>
+
+                <!-- 구분선 -->
+                <tr>
+                    <td style="padding: 20px 0;">
+                        <hr style="border:0; border-top:1px solid #ececec;">
+                    </td>
+                </tr>
+
+                <!-- 푸터 -->
+                <tr>
+                    <td style="font-size:13px; color:#999999; text-align:center;">
+                        본 이메일은 발신 전용입니다. 문의는 고객센터를 이용해주세요.<br/>
+                        &copy; 2025 Boilerplate. All rights reserved.
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>

--- a/src/main/resources/templates/mail/auth/retrieve-password.html
+++ b/src/main/resources/templates/mail/auth/retrieve-password.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org"
+      lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>보일러플레이트 - 비밀번호 재설정 인증번호</title>
+</head>
+
+<body style="margin:0; padding:0; background-color:#f6f6f6; font-family:Arial, sans-serif;">
+
+<!-- 전체 wrapper -->
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f6f6f6; padding: 30px 0;">
+    <tr>
+        <td align="center">
+
+            <!-- 카드 영역 -->
+            <table width="600" cellpadding="0" cellspacing="0"
+                   style="background:#ffffff; border-radius:8px; padding:40px;">
+
+                <!-- 타이틀 -->
+                <tr>
+                    <td align="center" style="padding-bottom: 20px;">
+                        <h1 style="margin:0; font-size:28px; color:#333333; font-weight:bold;">
+                            보일러플레이트
+                        </h1>
+                    </td>
+                </tr>
+
+                <!-- 내용 -->
+                <tr>
+                    <td style="font-size:16px; color:#333333; line-height:1.6; text-align:center;">
+
+                        <p style="margin:20px 0;">
+                            비밀번호 재설정을 위한
+                            <br/>
+                            인증번호를 안내드립니다.
+                        </p>
+
+                        <p style="margin:20px 0;">
+                            아래의 6자리 숫자 인증번호를
+                            <br/>
+                            비밀번호 재설정 화면에 입력해 주세요.
+                        </p>
+
+                        <!-- 인증번호 박스 -->
+                        <table align="center" cellpadding="0" cellspacing="0" style="margin: 20px auto;">
+                            <tr>
+                                <td style="
+                                    padding: 14px 26px;
+                                    border-radius: 6px;
+                                    background-color:#f5f5f5;
+                                    font-size:22px;
+                                    font-weight:bold;
+                                    letter-spacing:6px;
+                                    color:#333333;
+                                ">
+                                    <!-- 인증 코드 -->
+                                    <span th:text="${code}">123456</span>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <p style="margin:20px 0; font-size:14px; color:#666666;">
+                            보안을 위해 인증번호의 유효 시간은 제한적일 수 있습니다.
+                            <br/>
+                            인증번호를 타인과 공유하지 말아주세요.
+                        </p>
+
+                        <p style="margin:20px 0; font-size:13px; color:#999999;">
+                            만약 본인이 요청하지 않은 메일이라면,<br/>
+                            로그인 후 비밀번호 변경 또는 고객센터 문의를 통해<br/>
+                            계정 보안을 다시 한 번 확인해 주세요.
+                        </p>
+                    </td>
+                </tr>
+
+                <!-- 구분선 -->
+                <tr>
+                    <td style="padding: 20px 0;">
+                        <hr style="border:0; border-top:1px solid #ececec;">
+                    </td>
+                </tr>
+
+                <!-- 푸터 -->
+                <tr>
+                    <td style="font-size:13px; color:#999999; text-align:center;">
+                        본 이메일은 발신 전용입니다. 문의는 고객센터를 이용해주세요.<br/>
+                        &copy; 2025 Boilerplate. All rights reserved.
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>

--- a/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
@@ -14,20 +14,26 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.ResetPassword;
 import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
 import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.exception.UnauthorizedException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.support.fixture.UserFixture;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
+
+import io.jsonwebtoken.Claims;
 
 @ExtendWith(MockitoExtension.class)
 class AccountRecoveryServiceTest {
@@ -37,6 +43,7 @@ class AccountRecoveryServiceTest {
 	@Mock MailSender mailSender;
 	@Mock VerificationCodeStore verificationCodeStore;
 	@Mock JwtUtil jwtUtil;
+	@Mock BCryptPasswordEncoder bCryptPasswordEncoder;
 
 	@Nested
 	@DisplayName("아이디 찾기 기능")
@@ -299,6 +306,83 @@ class AccountRecoveryServiceTest {
 
 			//then
 		    Assertions.assertThat(passwordCodeVerified.token()).isEqualTo(token);
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀번호 초기화 기능")
+	class ResetPasswordByVerificationToken {
+		@Test
+		void 아이디로_회원을_조회한다() {
+		    //given
+			String loginId = "testLoginId";
+			String token = "testToken";
+			String password = "test@1234";
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+			Claims claims = Mockito.mock(Claims.class);
+			Mockito.when(claims.getSubject()).thenReturn(loginId);
+
+			Mockito.when(jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, token))
+				.thenReturn(claims);
+
+			Mockito.when(userRepository.findUserByLoginId(claims.getSubject()))
+				.thenReturn(Optional.of(UserFixture.USER_FIXTURE_1.create()));
+
+		    //when
+		    accountRecoveryService.resetPasswordByVerificationToken(resetPassword);
+
+		    //then
+		    Mockito.verify(userRepository, Mockito.times(1))
+				.findUserByLoginId(claims.getSubject());
+		}
+
+		@Test
+		void 아이디에_해당하는_회원이_없다면_예외를_반환한다() {
+		    //given
+			String loginId = "testLoginId";
+			String token = "testToken";
+			String password = "test@1234";
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+			Claims claims = Mockito.mock(Claims.class);
+			Mockito.when(claims.getSubject()).thenReturn(loginId);
+
+			Mockito.when(jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, token))
+				.thenReturn(claims);
+
+			Mockito.when(userRepository.findUserByLoginId(claims.getSubject()))
+				.thenThrow(new UnauthorizedException(AuthorizationErrorMessages.AUTH_USER_NOT_FOUND));
+
+		    //when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.resetPasswordByVerificationToken(resetPassword))
+				.isInstanceOf(UnauthorizedException.class);
+
+		}
+
+		@Test
+		void 새로운_비밀번호로_초기화한다() {
+		    //given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			String token = "testToken";
+			String password = "test@1234";
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+			Claims claims = Mockito.mock(Claims.class);
+			Mockito.when(claims.getSubject()).thenReturn(user.getLoginId());
+
+			Mockito.when(jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, token))
+				.thenReturn(claims);
+
+			Mockito.when(userRepository.findUserByLoginId(claims.getSubject()))
+				.thenReturn(Optional.of(user));
+			Mockito.when(bCryptPasswordEncoder.encode(password)).thenReturn(password);
+
+		    //when
+		    accountRecoveryService.resetPasswordByVerificationToken(resetPassword);
+
+		    //then
+		    Assertions.assertThat(user.getPassword()).isEqualTo(password);
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
@@ -1,0 +1,197 @@
+package com.hello.boilerplate.auth.application;
+
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
+import com.hello.boilerplate.support.fixture.UserFixture;
+import com.hello.boilerplate.user.domain.User;
+import com.hello.boilerplate.user.domain.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AccountRecoveryServiceTest {
+	@InjectMocks AccountRecoveryService accountRecoveryService;
+	@Mock UserRepository userRepository;
+	@Mock TemplateRenderer templateRenderer;
+	@Mock MailSender mailSender;
+	@Mock VerificationCodeStore verificationCodeStore;
+
+	@Nested
+	@DisplayName("아이디 찾기 기능")
+	class RetrieveLoginId {
+		@Test
+		void 이메일에_해당하는_사용자가_있는지_확인한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+
+			//when
+			accountRecoveryService.retrieveLoginId(findLoginId);
+
+			//then
+			Mockito.verify(userRepository, Mockito.times(1)).findUserByEmail(findLoginId.email());
+		}
+
+		@Test
+		void 이메일에_해당하는_사용자가_없다면_예외를_반환한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.empty());
+
+			//when & then
+			assertThatThrownBy(() -> accountRecoveryService.retrieveLoginId(findLoginId))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 요청된_이메일로_메일_템플릿을_작성한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn("mailContent");
+			//when
+			accountRecoveryService.retrieveLoginId(findLoginId);
+
+			//then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 아이디_찾기_이메일을_전송한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+			String mailContent = "mailContent";
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn(mailContent);
+
+			//when
+			accountRecoveryService.retrieveLoginId(findLoginId);
+
+			//then
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀 번호 찾기 기능")
+	class RetrievePassword {
+		@Test
+		void 로그인_아이디로_사용자를_조회한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			Mockito.when(userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email()))
+				.thenReturn(Optional.of(user));
+
+			//when
+			accountRecoveryService.retrievePassword(findPassword);
+
+			//then
+			Mockito.verify(userRepository, Mockito.times(1))
+				.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email());
+		}
+
+		@Test
+		void 로그인_아이디에_맞는_사용자가_없으면_예외를_반환한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			Mockito.when(userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email()))
+				.thenReturn(Optional.empty());
+
+			//when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.retrievePassword(findPassword))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 비밀번호_찾기_인증번호를_저장한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			Mockito.when(userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email()))
+				.thenReturn(Optional.of(user));
+			Mockito.doNothing().when(verificationCodeStore).save(Mockito.any(),Mockito.any(), Mockito.any());
+
+			//when
+			accountRecoveryService.retrievePassword(findPassword);
+
+			//then
+			Mockito.verify(verificationCodeStore, Mockito.times(1))
+				.save(Mockito.any(),Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 비밀번호_찾기_템플릿을_작성한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			Mockito.when(userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email()))
+				.thenReturn(Optional.of(user));
+			Mockito.doNothing().when(verificationCodeStore).save(Mockito.any(),Mockito.any(), Mockito.any());
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn("mailContent");
+
+			//when
+			accountRecoveryService.retrievePassword(findPassword);
+
+			//then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 비밀번호_찾기_이메일을_전송한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			Mockito.when(userRepository.findUserByLoginIdAndEmail(findPassword.loginId(), findPassword.email()))
+				.thenReturn(Optional.of(user));
+			Mockito.doNothing().when(verificationCodeStore).save(Mockito.any(),Mockito.any(), Mockito.any());
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn("mailContent");
+			Mockito.doNothing().when(mailSender).send(Mockito.any(), Mockito.any(), Mockito.any());
+
+			//when
+			accountRecoveryService.retrievePassword(findPassword);
+
+			//then
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
+		}
+	}
+
+}

--- a/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AccountRecoveryServiceTest.java
@@ -15,8 +15,13 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
+import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
+import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
@@ -31,6 +36,7 @@ class AccountRecoveryServiceTest {
 	@Mock TemplateRenderer templateRenderer;
 	@Mock MailSender mailSender;
 	@Mock VerificationCodeStore verificationCodeStore;
+	@Mock JwtUtil jwtUtil;
 
 	@Nested
 	@DisplayName("아이디 찾기 기능")
@@ -194,4 +200,105 @@ class AccountRecoveryServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("인증 번호 검증 기능")
+	class VerifyCode {
+		@Test
+		void 인증_번호를_조회한다() {
+		    //given
+			String code = "123456";
+			User user = UserFixture.USER_FIXTURE_1.create();
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(user.getLoginId(), code);
+
+			Mockito.when(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId()))
+				.thenReturn(code);
+
+			//when
+		    accountRecoveryService.verifyCode(verifyPasswordCode);
+
+		    //then
+		    Mockito.verify(verificationCodeStore, Mockito.times(1))
+				.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId());
+		}
+
+		@Test
+		void 인증번호가_올바르지_않다면_예외를_반환한다() {
+		    //given
+			String code = "123456";
+			User user = UserFixture.USER_FIXTURE_1.create();
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(user.getLoginId(), code);
+
+			String otherCode = "654321";
+			Mockito.when(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId()))
+				.thenReturn(otherCode);
+
+		    //when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.verifyCode(verifyPasswordCode))
+				.isInstanceOf(CustomException.class);
+		}
+
+		@Test
+		void 사용된_인증번호는_삭제한다() {
+		    //given
+			String code = "123456";
+			User user = UserFixture.USER_FIXTURE_1.create();
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(user.getLoginId(), code);
+
+			Mockito.when(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId()))
+				.thenReturn(code);
+			Mockito.doNothing().when(verificationCodeStore).delete(Mockito.any(), Mockito.any());
+
+		    //when
+			accountRecoveryService.verifyCode(verifyPasswordCode);
+
+		    //then
+		    Mockito.verify(verificationCodeStore, Mockito.times(1))
+				.delete(Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 인증_토큰을_발행한다() {
+		    //given
+			String code = "123456";
+			User user = UserFixture.USER_FIXTURE_1.create();
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(user.getLoginId(), code);
+
+			Mockito.when(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId()))
+				.thenReturn(code);
+			Mockito.doNothing().when(verificationCodeStore).delete(Mockito.any(), Mockito.any());
+
+			String token = "testToken";
+			Mockito.when(jwtUtil.createVerificationToken(Mockito.any(), Mockito.any(), Mockito.any()))
+				.thenReturn(token);
+
+		    //when
+			accountRecoveryService.verifyCode(verifyPasswordCode);
+
+		    //then
+		    Mockito.verify(jwtUtil, Mockito.times(1))
+				.createVerificationToken(Mockito.any(), Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 인증_번호를_검증한다() {
+		    //given
+			String code = "123456";
+			User user = UserFixture.USER_FIXTURE_1.create();
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(user.getLoginId(), code);
+
+			Mockito.when(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, verifyPasswordCode.loginId()))
+				.thenReturn(code);
+			Mockito.doNothing().when(verificationCodeStore).delete(Mockito.any(), Mockito.any());
+
+			String token = "testToken";
+			Mockito.when(jwtUtil.createVerificationToken(Mockito.any(), Mockito.any(), Mockito.any()))
+				.thenReturn(token);
+
+		    //when
+			PasswordCodeVerified passwordCodeVerified = accountRecoveryService.verifyCode(verifyPasswordCode);
+
+			//then
+		    Assertions.assertThat(passwordCodeVerified.token()).isEqualTo(token);
+		}
+	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
@@ -16,13 +16,16 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
-import com.hello.boilerplate.auth.infrastructure.jwt.JwtConstants;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
+import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.support.fixture.UserFixture;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
@@ -37,6 +40,8 @@ class AuthServiceTest {
 	@Mock BCryptPasswordEncoder bCryptPasswordEncoder;
 	@Mock RefreshTokenStore refreshTokenStore;
 	@Mock JwtUtil jwtUtil;
+	@Mock TemplateRenderer templateRenderer;
+	@Mock MailSender mailSender;
 
 	@Nested
 	@DisplayName("인증(로그인) 기능")
@@ -389,6 +394,74 @@ class AuthServiceTest {
 
 			//then
 			Assertions.assertThat(result.accessToken()).isEqualTo(newAccessToken);
+		}
+	}
+
+	@Nested
+	@DisplayName("아이디 찾기 기능")
+	class RetrieveLoginId {
+		@Test
+		void 이메일에_해당하는_사용자가_있는지_확인한다() {
+		    //given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+
+		    //when
+			authService.retrieveLoginId(findLoginId);
+
+			//then
+		    Mockito.verify(userRepository, Mockito.times(1)).findUserByEmail(findLoginId.email());
+		}
+
+		@Test
+		void 이메일에_해당하는_사용자가_없다면_예외를_반환한다() {
+		    //given
+			User user = UserFixture.USER_FIXTURE_1.create();;
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.empty());
+
+		    //when & then
+			assertThatThrownBy(() -> authService.retrieveLoginId(findLoginId))
+				.isInstanceOf(NotFoundException.class);
+		}
+
+		@Test
+		void 요청된_이메일로_메일_템플릿을_작성한다() {
+		    //given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn("mailContent");
+		    //when
+			authService.retrieveLoginId(findLoginId);
+
+		    //then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 아이디_찾기_이메일을_전송한다() {
+		    //given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			FindLoginId findLoginId = new FindLoginId(user.getEmail());
+			String mailContent = "mailContent";
+
+			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
+			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
+				.thenReturn(mailContent);
+
+		    //when
+			authService.retrieveLoginId(findLoginId);
+
+		    //then
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
@@ -42,6 +43,7 @@ class AuthServiceTest {
 	@Mock JwtUtil jwtUtil;
 	@Mock TemplateRenderer templateRenderer;
 	@Mock MailSender mailSender;
+	@Mock VerificationCodeStore verificationCodeStore;
 
 	@Nested
 	@DisplayName("인증(로그인) 기능")
@@ -394,74 +396,6 @@ class AuthServiceTest {
 
 			//then
 			Assertions.assertThat(result.accessToken()).isEqualTo(newAccessToken);
-		}
-	}
-
-	@Nested
-	@DisplayName("아이디 찾기 기능")
-	class RetrieveLoginId {
-		@Test
-		void 이메일에_해당하는_사용자가_있는지_확인한다() {
-		    //given
-			User user = UserFixture.USER_FIXTURE_1.create();;
-			FindLoginId findLoginId = new FindLoginId(user.getEmail());
-
-			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
-
-		    //when
-			authService.retrieveLoginId(findLoginId);
-
-			//then
-		    Mockito.verify(userRepository, Mockito.times(1)).findUserByEmail(findLoginId.email());
-		}
-
-		@Test
-		void 이메일에_해당하는_사용자가_없다면_예외를_반환한다() {
-		    //given
-			User user = UserFixture.USER_FIXTURE_1.create();;
-			FindLoginId findLoginId = new FindLoginId(user.getEmail());
-
-			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.empty());
-
-		    //when & then
-			assertThatThrownBy(() -> authService.retrieveLoginId(findLoginId))
-				.isInstanceOf(NotFoundException.class);
-		}
-
-		@Test
-		void 요청된_이메일로_메일_템플릿을_작성한다() {
-		    //given
-			User user = UserFixture.USER_FIXTURE_1.create();
-			FindLoginId findLoginId = new FindLoginId(user.getEmail());
-
-			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
-			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
-				.thenReturn("mailContent");
-		    //when
-			authService.retrieveLoginId(findLoginId);
-
-		    //then
-			Mockito.verify(templateRenderer, Mockito.times(1))
-				.render(Mockito.any(), Mockito.any());
-		}
-
-		@Test
-		void 아이디_찾기_이메일을_전송한다() {
-		    //given
-			User user = UserFixture.USER_FIXTURE_1.create();
-			FindLoginId findLoginId = new FindLoginId(user.getEmail());
-			String mailContent = "mailContent";
-
-			Mockito.when(userRepository.findUserByEmail(findLoginId.email())).thenReturn(Optional.of(user));
-			Mockito.when(templateRenderer.render(Mockito.any(), Mockito.any()))
-				.thenReturn(mailContent);
-
-		    //when
-			authService.retrieveLoginId(findLoginId);
-
-		    //then
-			Mockito.verify(mailSender, Mockito.times(1))
-				.send(Mockito.any(), Mockito.any(), Mockito.any());
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/application/AuthServiceTest.java
@@ -18,15 +18,10 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
-import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
-import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
-import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
-import com.hello.boilerplate.common.infrastructure.mail.MailSender;
-import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.support.fixture.UserFixture;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
@@ -41,9 +36,6 @@ class AuthServiceTest {
 	@Mock BCryptPasswordEncoder bCryptPasswordEncoder;
 	@Mock RefreshTokenStore refreshTokenStore;
 	@Mock JwtUtil jwtUtil;
-	@Mock TemplateRenderer templateRenderer;
-	@Mock MailSender mailSender;
-	@Mock VerificationCodeStore verificationCodeStore;
 
 	@Nested
 	@DisplayName("인증(로그인) 기능")

--- a/src/test/java/com/hello/boilerplate/auth/infrastructure/RedisRefreshTokenStoreTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/infrastructure/RedisRefreshTokenStoreTest.java
@@ -27,12 +27,12 @@ class RedisRefreshTokenStoreTest {
 	private ValueOperations<String, String> valueOperations;
 
 	@Mock
-    private RedisTemplate<String, String> redisTemplate;
+    private RedisTemplate<String, String> stringRedisTemplate;
 
 	@BeforeEach
 	void setUp() {
 		Long expirationDays = 21L;
-		redisRefreshTokenStore = new RedisRefreshTokenStore(redisTemplate, expirationDays);
+		redisRefreshTokenStore = new RedisRefreshTokenStore(stringRedisTemplate, expirationDays);
 	}
 
 
@@ -40,7 +40,7 @@ class RedisRefreshTokenStoreTest {
     @Test
     void 재발급_토큰을_저장한다() {
         // given
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // when
         redisRefreshTokenStore.save(SUBJECT, REFRESH_TOKEN);
@@ -53,7 +53,7 @@ class RedisRefreshTokenStoreTest {
     @Test
     void 재발급_토큰을_조회한다() {
         // given
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(REFRESH_TOKEN_KEY)).thenReturn(REFRESH_TOKEN);
 
         // when
@@ -67,7 +67,7 @@ class RedisRefreshTokenStoreTest {
     @Test
     void 재발급_토큰이_조회되지_않는다면_null을_반환한다() {
         // given
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(REFRESH_TOKEN_KEY)).thenReturn(null);
 
         // when
@@ -81,12 +81,12 @@ class RedisRefreshTokenStoreTest {
     @Test
     void 재발급_토큰을_삭제한다() {
         // given
-        when(redisTemplate.delete(REFRESH_TOKEN_KEY)).thenReturn(true);
+        when(stringRedisTemplate.delete(REFRESH_TOKEN_KEY)).thenReturn(true);
 
         // when
         redisRefreshTokenStore.delete(SUBJECT);
 
         // then
-        verify(redisTemplate, times(1)).delete(REFRESH_TOKEN_KEY);
+        verify(stringRedisTemplate, times(1)).delete(REFRESH_TOKEN_KEY);
     }
 }

--- a/src/test/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtilTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtilTest.java
@@ -1,5 +1,6 @@
 package com.hello.boilerplate.auth.infrastructure.jwt;
 
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.support.fixture.UserFixture;
@@ -30,13 +31,16 @@ class JwtUtilTest {
 
     private static final String TEST_ACCESS_SECRET = "accessabcdefghijklmnopqrstuvwxyz";
     private static final String TEST_REFRESH_SECRET = "refreshabcdefghijklmnopqrstuvwxyz";
+	private static final String TEST_VERIFY_SECRET = "verificationabcdefghijklmnopqrstu";
     private static final Long TEST_EXPIRATION_DAYS = 21L;
+	private static final Long TEST_EXPIRATION_SECONDS = 60L * 10;
 
     @BeforeEach
     void setUp() {
         jwtUtil = new JwtUtil(
 			TEST_ACCESS_SECRET,
 			TEST_REFRESH_SECRET,
+			TEST_VERIFY_SECRET,
 			TEST_EXPIRATION_DAYS,
 			TEST_EXPIRATION_DAYS
         );
@@ -92,6 +96,37 @@ class JwtUtilTest {
 			assertAll(
 				() -> assertThat(refreshToken).isNotNull(),
 				() -> assertThat(claims.getSubject()).isEqualTo(user.getLoginId()),
+				() -> assertThat(claims.getIssuedAt()).isEqualTo(now),
+				() -> assertThat(claims.getExpiration()).isEqualTo(new Date(now.getTime() + expirationMs))
+			);
+		}
+	}
+
+	@Nested
+	@DisplayName("인증(임시) 토큰 생성 기능")
+	class CreateVerificationToken {
+		@Test
+		void 인증_토큰을_생성한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			long expirationMs = TEST_EXPIRATION_SECONDS * 1_000L;
+			String claimKey = "purpose";
+
+			Instant nowInstant = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+			Date now = Date.from(nowInstant);
+
+			//when
+			String verificationToken = jwtUtil.createVerificationToken(
+				VerificationPurpose.PASSWORD_RESET, user.getLoginId(), now
+			);
+
+			//then
+			Claims claims = getClaims(verificationToken, TEST_VERIFY_SECRET);
+
+			assertAll(
+				() -> assertThat(verificationToken).isNotNull(),
+				() -> assertThat(claims.getSubject()).isEqualTo(user.getLoginId()),
+				() -> assertThat(claims.get(claimKey)).isEqualTo(VerificationPurpose.PASSWORD_RESET.toString()),
 				() -> assertThat(claims.getIssuedAt()).isEqualTo(now),
 				() -> assertThat(claims.getExpiration()).isEqualTo(new Date(now.getTime() + expirationMs))
 			);

--- a/src/test/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtilTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/infrastructure/jwt/JwtUtilTest.java
@@ -289,6 +289,100 @@ class JwtUtilTest {
 				.isInstanceOf(UnauthorizedException.class);
 		}
 	}
+
+	@Nested
+	@DisplayName("인증(임시) 토큰 Claims 추출 기능")
+	class GetVerificationTokenClaims {
+		@Test
+		void VerificationToken_Claims을_추출한다() {
+			//given
+			String claimKey = "purpose";
+			User user = UserFixture.USER_FIXTURE_1.create();
+
+			long expirationMs = TEST_EXPIRATION_SECONDS * 1_000L;
+			Instant nowInstant = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+			Date now = Date.from(nowInstant);
+
+			String verificationToken = jwtUtil.createVerificationToken(VerificationPurpose.PASSWORD_RESET, user.getLoginId(), now);
+
+			//when
+			Claims claims = jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, verificationToken);
+
+			//then
+			assertAll(
+				() -> assertThat(verificationToken).isNotNull(),
+				() -> assertThat(claims.getSubject()).isEqualTo(user.getLoginId()),
+				() -> assertThat(claims.get(claimKey)).isEqualTo(VerificationPurpose.PASSWORD_RESET.toString()),
+				() -> assertThat(claims.getIssuedAt()).isEqualTo(now),
+				() -> assertThat(claims.getExpiration()).isEqualTo(new Date(now.getTime() + expirationMs))
+			);
+		}
+
+		@Test
+		void 잘못된_VerificationToken_형식으로_파싱에_실패한_경우_예외를_반환한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			String verificationToken = jwtUtil.createVerificationToken(
+				VerificationPurpose.PASSWORD_RESET, user.getLoginId(), new Date()
+			);
+
+			//when & then
+			assertThatThrownBy(() -> jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, "hacking" + verificationToken))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+
+		@Test
+		void VerificationToken이_null인_경우_예외를_반환한다() {
+			//given
+			String verificationToken = null;
+
+			//when & then
+			assertThatThrownBy(() -> jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, verificationToken))
+				.isInstanceOf(UnauthorizedException.class);
+
+		}
+
+		@Test
+		void VerificationToken이_공백인_경우_예외를_반환한다() {
+			//given
+			String verificationToken = "";
+
+			//when & then
+			assertThatThrownBy(() -> jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, verificationToken))
+				.isInstanceOf(UnauthorizedException.class);
+
+		}
+
+		@Test
+		void Claims의_subject가_없다면_예외를_반환한다() {
+			//given
+			User user = UserFixture.USER_FIXTURE_1.create();
+			String claimsKey = "purpose";
+
+			String verificationToken = Jwts.builder()
+				.claim(claimsKey, VerificationPurpose.PASSWORD_RESET)
+				.compact();
+
+			//when & then
+			assertThatThrownBy(() -> jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, verificationToken))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+
+		@Test
+		void Claims의_인증_목적이_다르다면_예외를_반환한다() {
+			//given
+			String claimsKey = "purpose";
+
+			String verificationToken = Jwts.builder()
+				.subject("testLoginId")
+				.claim(claimsKey, "otherPurpose")
+				.compact();
+
+			//when & then
+			assertThatThrownBy(() -> jwtUtil.getVerificationToken(VerificationPurpose.PASSWORD_RESET, verificationToken))
+				.isInstanceOf(UnauthorizedException.class);
+		}
+	}
 	
     private Claims getClaims(String token, String secret) {
         return Jwts.parser()

--- a/src/test/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStoreTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStoreTest.java
@@ -1,0 +1,83 @@
+package com.hello.boilerplate.auth.infrastructure.verification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class RedisVerificationCodeStoreTest {
+
+	private static final String TEST_LOGIN_ID = "test1";
+	private static final String TEST_CODE = "123456";
+	private static final String TEST_CODE_KEY = "code:password_reset:test1";
+	private static final Long EXPIRATION_SECONDS = 60L * 5;
+
+	@InjectMocks RedisVerificationCodeStore redisVerificationCodeStore;
+	@Mock RedisTemplate<String, String> stringRedisTemplate;
+	@Mock ValueOperations<String, String> valueOperations;
+
+	@Test
+	void 인증번호를_저장한다() {
+		// given
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+
+		// when
+		redisVerificationCodeStore.save(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID, TEST_CODE);
+
+		// then
+		verify(valueOperations, times(1))
+			.set(TEST_CODE_KEY, TEST_CODE, EXPIRATION_SECONDS, TimeUnit.SECONDS);
+	}
+
+	@Test
+	void 인증번호를_조회한다() {
+		// given
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(TEST_CODE_KEY)).thenReturn(TEST_CODE);
+
+		// when
+		String result = redisVerificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+
+		// then
+		assertThat(result).isEqualTo(TEST_CODE);
+		verify(valueOperations, times(1)).get(TEST_CODE_KEY);
+	}
+
+	@Test
+	void 인증번호가_조회되지_않는다면_null을_반환한다() {
+		// given
+		when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+		when(valueOperations.get(TEST_CODE_KEY)).thenReturn(null);
+
+		// when
+		String resultRefreshToken = redisVerificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+
+		// then
+		assertThat(resultRefreshToken).isNull();
+		verify(valueOperations, times(1)).get(TEST_CODE_KEY);
+	}
+
+	@Test
+	void 인증번호를_삭제한다() {
+		// given
+		when(stringRedisTemplate.delete(TEST_CODE_KEY)).thenReturn(true);
+
+		// when
+		redisVerificationCodeStore.delete(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+
+		// then
+		verify(stringRedisTemplate, times(1)).delete(TEST_CODE_KEY);
+	}
+
+}

--- a/src/test/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStoreTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/infrastructure/verification/RedisVerificationCodeStoreTest.java
@@ -33,7 +33,7 @@ class RedisVerificationCodeStoreTest {
 		when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
 
 		// when
-		redisVerificationCodeStore.save(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID, TEST_CODE);
+		redisVerificationCodeStore.save(VerificationPurpose.PASSWORD_RESET, TEST_LOGIN_ID, TEST_CODE);
 
 		// then
 		verify(valueOperations, times(1))
@@ -47,7 +47,7 @@ class RedisVerificationCodeStoreTest {
 		when(valueOperations.get(TEST_CODE_KEY)).thenReturn(TEST_CODE);
 
 		// when
-		String result = redisVerificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+		String result = redisVerificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, TEST_LOGIN_ID);
 
 		// then
 		assertThat(result).isEqualTo(TEST_CODE);
@@ -61,7 +61,7 @@ class RedisVerificationCodeStoreTest {
 		when(valueOperations.get(TEST_CODE_KEY)).thenReturn(null);
 
 		// when
-		String resultRefreshToken = redisVerificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+		String resultRefreshToken = redisVerificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, TEST_LOGIN_ID);
 
 		// then
 		assertThat(resultRefreshToken).isNull();
@@ -74,7 +74,7 @@ class RedisVerificationCodeStoreTest {
 		when(stringRedisTemplate.delete(TEST_CODE_KEY)).thenReturn(true);
 
 		// when
-		redisVerificationCodeStore.delete(VerificationCodeType.PASSWORD_RESET, TEST_LOGIN_ID);
+		redisVerificationCodeStore.delete(VerificationPurpose.PASSWORD_RESET, TEST_LOGIN_ID);
 
 		// then
 		verify(stringRedisTemplate, times(1)).delete(TEST_CODE_KEY);

--- a/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
@@ -114,7 +114,7 @@ public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTes
 		@Test
 		void 요청_데이터와_일치하는_사용자가_없으면_예외를_반환한다() {
 			//given
-			User otherUser = UserFixture.USER_FIXTURE_2.create();;
+			User otherUser = UserFixture.USER_FIXTURE_2.create();
 			FindPassword findPassword = new FindPassword(otherUser.getLoginId(), otherUser.getEmail());
 
 			//when

--- a/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.hello.boilerplate.auth.integration;
 
+import java.util.Date;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,16 +18,20 @@ import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.ResetPassword;
 import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
 import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.exception.UnauthorizedException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.support.IntegrationSupportTest;
 import com.hello.boilerplate.support.fixture.UserFixture;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
+
+import io.jsonwebtoken.Claims;
 
 public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTest {
 
@@ -148,6 +154,44 @@ public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTes
 		    //when & then
 			Assertions.assertThatThrownBy(() -> accountRecoveryService.verifyCode(verifyPasswordCode))
 				.isInstanceOf(CustomException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀번호 초기화 기능")
+	class ResetPasswordByVerificationToken {
+		@Test
+		void 비밀번호를_초기화_한다() {
+		    //given
+			String token = jwtUtil.createVerificationToken(
+				VerificationPurpose.PASSWORD_RESET,
+				user.getLoginId(),
+				new Date()
+			);
+			String password = "test@1234";
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+			//when
+		    accountRecoveryService.resetPasswordByVerificationToken(resetPassword);
+
+		    //then
+		    Assertions.assertThat(bCryptPasswordEncoder.matches(password, user.getPassword())).isTrue();
+		}
+
+		@Test
+		void 토큰에_해당하는_사용자가_없다면_예외를_반환한다() {
+		    //given
+			String token = jwtUtil.createVerificationToken(
+				VerificationPurpose.PASSWORD_RESET,
+				"wrongLoginId",
+				new Date()
+			);
+			String password = "test@1234";
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+		    //when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.resetPasswordByVerificationToken(resetPassword))
+				.isInstanceOf(UnauthorizedException.class);
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.hello.boilerplate.auth.integration;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.hello.boilerplate.auth.application.AccountRecoveryService;
+import com.hello.boilerplate.auth.application.VerificationCodeStore;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.common.exception.NotFoundException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
+import com.hello.boilerplate.support.IntegrationSupportTest;
+import com.hello.boilerplate.support.fixture.UserFixture;
+import com.hello.boilerplate.user.domain.User;
+import com.hello.boilerplate.user.domain.UserRepository;
+
+public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTest {
+
+	@Autowired AccountRecoveryService accountRecoveryService;
+	@Autowired UserRepository userRepository;
+	@Autowired BCryptPasswordEncoder bCryptPasswordEncoder;
+	@Autowired VerificationCodeStore verificationCodeStore;
+	@MockitoBean MailSender mailSender;
+	@MockitoBean TemplateRenderer templateRenderer;
+
+	private User user;
+
+	@BeforeEach
+	void setUp() {
+		User userFixture = UserFixture.USER_FIXTURE_1.create();
+
+		user = userRepository.save(
+			new User(
+				userFixture.getLoginId(),
+				bCryptPasswordEncoder.encode(userFixture.getPassword()),
+				userFixture.getEmail(),
+				userFixture.getName(),
+				userFixture.getRole()
+			)
+		);
+	}
+
+	@Nested
+	@DisplayName("아이디 찾기 기능")
+	class RetrieveLoginId {
+		@Test
+		void 아이디_찾기_이메일을_전송한다() {
+			//given
+			String email = user.getEmail();
+			FindLoginId findLoginId = new FindLoginId(email);
+
+			//when
+			accountRecoveryService.retrieveLoginId(findLoginId);
+
+			//then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 요청된_이메일에_맞는_사용자가_없다면_예외를_반환한다() {
+			//given
+			String email = "wrong@wrong.com";
+			FindLoginId findLoginId = new FindLoginId(email);
+
+			//when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.retrieveLoginId(findLoginId))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀 번호 찾기 기능")
+	class RetrievePassword {
+		@Test
+		void 비밀번호_찾기_이메일을_전송한다() {
+			//given
+			FindPassword findPassword = new FindPassword(user.getLoginId(), user.getEmail());
+
+			//when
+			accountRecoveryService.retrievePassword(findPassword);
+
+			//then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
+
+			Assertions.assertThat(verificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, findPassword.loginId())).isInstanceOf(String.class);
+		}
+
+		@Test
+		void 요청_데이터와_일치하는_사용자가_없으면_예외를_반환한다() {
+			//given
+			User otherUser = UserFixture.USER_FIXTURE_2.create();;
+			FindPassword findPassword = new FindPassword(otherUser.getLoginId(), otherUser.getEmail());
+
+			//when
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.retrievePassword(findPassword))
+				.isInstanceOf(NotFoundException.class);
+		}
+	}
+}

--- a/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.application.VerificationCodeStore;
-import com.hello.boilerplate.auth.infrastructure.verification.VerificationCodeType;
+import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
 import com.hello.boilerplate.common.exception.NotFoundException;
@@ -97,7 +97,7 @@ public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTes
 			Mockito.verify(mailSender, Mockito.times(1))
 				.send(Mockito.any(), Mockito.any(), Mockito.any());
 
-			Assertions.assertThat(verificationCodeStore.get(VerificationCodeType.PASSWORD_RESET, findPassword.loginId())).isInstanceOf(String.class);
+			Assertions.assertThat(verificationCodeStore.get(VerificationPurpose.PASSWORD_RESET, findPassword.loginId())).isInstanceOf(String.class);
 		}
 
 		@Test

--- a/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AccountRecoveryServiceIntegrationTest.java
@@ -12,9 +12,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.auth.application.VerificationCodeStore;
+import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.auth.infrastructure.verification.VerificationPurpose;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
+import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
+import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.infrastructure.mail.MailSender;
 import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
@@ -29,6 +33,7 @@ public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTes
 	@Autowired UserRepository userRepository;
 	@Autowired BCryptPasswordEncoder bCryptPasswordEncoder;
 	@Autowired VerificationCodeStore verificationCodeStore;
+	@Autowired JwtUtil jwtUtil;
 	@MockitoBean MailSender mailSender;
 	@MockitoBean TemplateRenderer templateRenderer;
 
@@ -109,6 +114,40 @@ public class AccountRecoveryServiceIntegrationTest extends IntegrationSupportTes
 			//when
 			Assertions.assertThatThrownBy(() -> accountRecoveryService.retrievePassword(findPassword))
 				.isInstanceOf(NotFoundException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("인증 번호 검증 기능")
+	class VerifyCode {
+		@Test
+		void 인증번호를_검증한다() {
+		    //given
+			String loginId = user.getLoginId();
+			String code = "123456";
+			verificationCodeStore.save(VerificationPurpose.PASSWORD_RESET, loginId, code);
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(loginId, code);
+
+			//when
+			PasswordCodeVerified passwordCodeVerified = accountRecoveryService.verifyCode(verifyPasswordCode);
+
+			//then
+		    Assertions.assertThat(passwordCodeVerified.token()).isNotNull();
+		}
+
+		@Test
+		void 인증번호가_올바르지_않은_경우_예외를_반환한다() {
+		    //given
+			String loginId = user.getLoginId();
+			String code = "123456";
+			verificationCodeStore.save(VerificationPurpose.PASSWORD_RESET, loginId, code);
+
+			String wrongCode = "654321";
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(loginId, wrongCode);
+
+		    //when & then
+			Assertions.assertThatThrownBy(() -> accountRecoveryService.verifyCode(verifyPasswordCode))
+				.isInstanceOf(CustomException.class);
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/integration/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AuthServiceIntegrationTest.java
@@ -3,11 +3,15 @@ package com.hello.boilerplate.auth.integration;
 import com.hello.boilerplate.auth.application.AuthService;
 import com.hello.boilerplate.auth.application.RefreshTokenStore;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.common.exception.CustomException;
+import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
+import com.hello.boilerplate.common.infrastructure.mail.MailSender;
+import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
 import com.hello.boilerplate.support.fixture.UserFixture;
@@ -18,8 +22,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Date;
 
@@ -34,6 +40,8 @@ class AuthServiceIntegrationTest extends IntegrationSupportTest {
 	@Autowired BCryptPasswordEncoder bCryptPasswordEncoder;
 	@Autowired RefreshTokenStore refreshTokenStore;
 	@Autowired JwtUtil jwtUtil;
+	@MockitoBean MailSender mailSender;
+	@MockitoBean TemplateRenderer templateRenderer;
 
     private User user;
 
@@ -168,6 +176,37 @@ class AuthServiceIntegrationTest extends IntegrationSupportTest {
 		    //when & then
 			Assertions.assertThatThrownBy(() -> authService.reissueToken(otherUserRefreshToken))
 				.isInstanceOf(UnauthorizedException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("아이디 찾기 기능")
+	class RetrieveLoginId {
+		@Test
+		void 아이디_찾기_이메일을_전송한다() {
+		    //given
+			String email = user.getEmail();
+			FindLoginId findLoginId = new FindLoginId(email);
+
+			//when
+			authService.retrieveLoginId(findLoginId);
+
+		    //then
+			Mockito.verify(templateRenderer, Mockito.times(1))
+				.render(Mockito.any(), Mockito.any());
+			Mockito.verify(mailSender, Mockito.times(1))
+				.send(Mockito.any(), Mockito.any(), Mockito.any());
+		}
+
+		@Test
+		void 요청된_이메일에_맞는_사용자가_없다면_예외를_반환한다() {
+		    //given
+			String email = "wrong@wrong.com";
+			FindLoginId findLoginId = new FindLoginId(email);
+
+		    //when & then
+		    Assertions.assertThatThrownBy(() -> authService.retrieveLoginId(findLoginId))
+				.isInstanceOf(NotFoundException.class);
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/integration/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/integration/AuthServiceIntegrationTest.java
@@ -3,15 +3,11 @@ package com.hello.boilerplate.auth.integration;
 import com.hello.boilerplate.auth.application.AuthService;
 import com.hello.boilerplate.auth.application.RefreshTokenStore;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
-import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.auth.infrastructure.jwt.JwtUtil;
 import com.hello.boilerplate.common.exception.CustomException;
-import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
-import com.hello.boilerplate.common.infrastructure.mail.MailSender;
-import com.hello.boilerplate.common.infrastructure.mail.TemplateRenderer;
 import com.hello.boilerplate.user.domain.User;
 import com.hello.boilerplate.user.domain.UserRepository;
 import com.hello.boilerplate.support.fixture.UserFixture;
@@ -22,10 +18,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Date;
 
@@ -40,8 +34,6 @@ class AuthServiceIntegrationTest extends IntegrationSupportTest {
 	@Autowired BCryptPasswordEncoder bCryptPasswordEncoder;
 	@Autowired RefreshTokenStore refreshTokenStore;
 	@Autowired JwtUtil jwtUtil;
-	@MockitoBean MailSender mailSender;
-	@MockitoBean TemplateRenderer templateRenderer;
 
     private User user;
 
@@ -176,37 +168,6 @@ class AuthServiceIntegrationTest extends IntegrationSupportTest {
 		    //when & then
 			Assertions.assertThatThrownBy(() -> authService.reissueToken(otherUserRefreshToken))
 				.isInstanceOf(UnauthorizedException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("아이디 찾기 기능")
-	class RetrieveLoginId {
-		@Test
-		void 아이디_찾기_이메일을_전송한다() {
-		    //given
-			String email = user.getEmail();
-			FindLoginId findLoginId = new FindLoginId(email);
-
-			//when
-			authService.retrieveLoginId(findLoginId);
-
-		    //then
-			Mockito.verify(templateRenderer, Mockito.times(1))
-				.render(Mockito.any(), Mockito.any());
-			Mockito.verify(mailSender, Mockito.times(1))
-				.send(Mockito.any(), Mockito.any(), Mockito.any());
-		}
-
-		@Test
-		void 요청된_이메일에_맞는_사용자가_없다면_예외를_반환한다() {
-		    //given
-			String email = "wrong@wrong.com";
-			FindLoginId findLoginId = new FindLoginId(email);
-
-		    //when & then
-		    Assertions.assertThatThrownBy(() -> authService.retrieveLoginId(findLoginId))
-				.isInstanceOf(NotFoundException.class);
 		}
 	}
 }

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -3,9 +3,11 @@ package com.hello.boilerplate.auth.presentation;
 import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.hello.boilerplate.auth.exception.AuthorizationErrorMessages;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.ResetPassword;
 import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
@@ -596,6 +598,83 @@ class AuthControllerTest extends RestDocsSupport {
 				.andExpect(status().isBadRequest())
 				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
 				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀번호 초기화 기능 API 테스트")
+	class PasswordReset {
+		@Test
+		void 비밀번호_초기화_2XX() throws Exception {
+			//given
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String password = userFixture.getPassword();
+			String token = "testToken";
+
+			ResetPassword resetPassword = new ResetPassword(token, password);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/reset")
+					.content(objectMapper.writeValueAsString(resetPassword))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data").isEmpty())
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("3. 비밀번호 초기화")
+							.description("## 3. 비밀번호 초기화 기능 \n"
+								+ "### 사용법 \n"
+								+ "- 인증번호를 통해 얻은 임시 토큰을 통해 사용자의 비밀번호를 새롭게 초기화 합니다.\n"
+							)
+							.requestSchema(Schema.schema(ResetPassword.class.getSimpleName()))
+							.requestFields(
+								fieldWithPath("token").description("인증번호로 얻은 임시 토큰입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("password").description("새로운 비밀번호 입니다.").type(JsonFieldType.STRING)
+							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.build()
+						)
+					)
+				);
+
+		}
+
+		@Test
+		void 비밀번호_초기화_4XX_토큰이_올바르지_않은_경우() throws Exception {
+			//given
+
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String password = userFixture.getPassword();
+			String wrongToken = "wrongToken";
+			ResetPassword resetPassword = new ResetPassword(wrongToken, password);
+
+			Mockito.doThrow(new UnauthorizedException(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION))
+				.when(accountRecoveryService).resetPasswordByVerificationToken(resetPassword);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/reset")
+					.content(objectMapper.writeValueAsString(resetPassword))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isUnauthorized())
+				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION))
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -433,6 +433,7 @@ class AuthControllerTest extends RestDocsSupport {
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(FindLoginId.class.getSimpleName()))
 							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)
@@ -655,7 +656,6 @@ class AuthControllerTest extends RestDocsSupport {
 		@Test
 		void 비밀번호_초기화_4XX_토큰이_올바르지_않은_경우() throws Exception {
 			//given
-
 			User userFixture = UserFixture.USER_FIXTURE_1.create();
 			String password = userFixture.getPassword();
 			String wrongToken = "wrongToken";
@@ -673,11 +673,12 @@ class AuthControllerTest extends RestDocsSupport {
 			//then
 			actions
 				.andExpect(status().isUnauthorized())
-				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
+				.andExpect(result -> Assertions.assertInstanceOf(UnauthorizedException.class, result.getResolvedException()))
 				.andExpect(jsonPath("$.message").value(AuthorizationErrorMessages.INVALID_TOKEN_EXCEPTION))
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
 							.tag(BASE_TAG)
+							.requestSchema(Schema.schema(ResetPassword.class.getSimpleName()))
 							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
 							.build())
 					)

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -4,9 +4,11 @@ import com.epages.restdocs.apispec.ResourceDocumentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
+import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
+import com.hello.boilerplate.common.exception.NotFoundException;
 import com.hello.boilerplate.common.exception.UnauthorizedException;
 import com.hello.boilerplate.common.presentation.dto.ApiErrorResponse;
 import com.hello.boilerplate.common.presentation.dto.ApiResponse;
@@ -347,6 +349,81 @@ class AuthControllerTest extends RestDocsSupport {
 			actions
 				.andExpect(status().isUnauthorized())
 				.andExpect(result -> Assertions.assertInstanceOf(UnauthorizedException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("아이디 찾기 기능 API 테스트")
+	class retrieveLoginId {
+		@Test
+		void 아이디_찾기_2XX() throws Exception {
+		    //given
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String email = userFixture.getEmail();
+			FindLoginId findLoginId = new FindLoginId(email);
+			Mockito.doNothing().when(authService).retrieveLoginId(findLoginId);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/find-id")
+					.content(objectMapper.writeValueAsString(findLoginId))
+					.contentType(MediaType.APPLICATION_JSON));
+
+		    //then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data").isEmpty())
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("아이디 찾기")
+							.description("## 아이디 찾기 기능 \n"
+								+ "### 설명 \n"
+								+ "- 해당하는 이메일에 아이디를 전송합니다.\n"
+							)
+							.requestSchema(Schema.schema(FindLoginId.class.getSimpleName()))
+							.requestFields(
+								fieldWithPath("email").description("아이디를 전송할 이메일입니다.").type(JsonFieldType.STRING)
+							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.build()
+						)
+					)
+				);
+
+		}
+
+		@Test
+		void 아이디_찾기_4XX_이메일에_해당하는_사용자가_없는_경우() throws Exception {
+		    //given
+			String errorMessage = User.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String email = userFixture.getEmail();
+			FindLoginId findLoginId = new FindLoginId(email);
+
+			Mockito.doThrow(new NotFoundException(User.class))
+				.when(authService).retrieveLoginId(findLoginId);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/find-id")
+					.content(objectMapper.writeValueAsString(findLoginId))
+					.contentType(MediaType.APPLICATION_JSON));
+
+		    //then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
 				.andExpect(jsonPath("$.message").value(errorMessage))
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -369,7 +369,7 @@ class AuthControllerTest extends RestDocsSupport {
 			User userFixture = UserFixture.USER_FIXTURE_1.create();
 			String email = userFixture.getEmail();
 			FindLoginId findLoginId = new FindLoginId(email);
-			Mockito.doNothing().when(authService).retrieveLoginId(findLoginId);
+			Mockito.doNothing().when(accountRecoveryService).retrieveLoginId(findLoginId);
 
 			//when
 			ResultActions actions = mockMvc.perform(
@@ -412,7 +412,7 @@ class AuthControllerTest extends RestDocsSupport {
 			FindLoginId findLoginId = new FindLoginId(email);
 
 			Mockito.doThrow(new NotFoundException(User.class))
-				.when(authService).retrieveLoginId(findLoginId);
+				.when(accountRecoveryService).retrieveLoginId(findLoginId);
 
 			//when
 			ResultActions actions = mockMvc.perform(

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -5,6 +5,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
+import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
@@ -421,6 +422,87 @@ class AuthControllerTest extends RestDocsSupport {
 					.contentType(MediaType.APPLICATION_JSON));
 
 		    //then
+			actions
+				.andExpect(status().isNotFound())
+				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("비밀번호 찾기 기능 API 테스트")
+	class retrievePassword {
+		@Test
+		void 비밀번호_찾기_2XX() throws Exception {
+			//given
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String loginId = userFixture.getLoginId();
+			String email = userFixture.getEmail();
+
+			FindPassword findPassword = new FindPassword(loginId, email);
+			Mockito.doNothing().when(accountRecoveryService).retrievePassword(findPassword);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/find")
+					.content(objectMapper.writeValueAsString(findPassword))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data").isEmpty())
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("1. 비밀번호 찾기")
+							.description("## 1. 비밀번호 찾기 기능 \n"
+								+ "### 사용법 \n"
+								+ "- 해당하는 이메일에 인증번호를 전송합니다.\n"
+								+ "- 해당하는 인증번호를 비밀번호 찾기 인증번호 검증 요청에 사용해주세요.\n"
+							)
+							.requestSchema(Schema.schema(FindPassword.class.getSimpleName()))
+							.requestFields(
+								fieldWithPath("loginId").description("사용자의 아이디입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("email").description("사용자의 이메일입니다.").type(JsonFieldType.STRING)
+							)
+							.responseSchema(Schema.schema(ApiResponse.class.getSimpleName()))
+							.build()
+						)
+					)
+				);
+
+		}
+
+		@Test
+		void 비밀번호_찾기_4XX_데이터에_해당하는_사용자가_없는_경우() throws Exception {
+			//given
+			String errorMessage = User.class.getSimpleName() + "을(를) 찾을 수 없습니다.";
+
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String loginId = userFixture.getLoginId();
+			String email = userFixture.getEmail();
+
+			FindPassword findPassword = new FindPassword(loginId, email);
+
+			Mockito.doThrow(new NotFoundException(User.class))
+				.when(accountRecoveryService).retrievePassword(findPassword);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/find")
+					.content(objectMapper.writeValueAsString(findPassword))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
 			actions
 				.andExpect(status().isNotFound())
 				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -373,7 +373,7 @@ class AuthControllerTest extends RestDocsSupport {
 
 			//when
 			ResultActions actions = mockMvc.perform(
-				post(BASE_URI + "/find-id")
+				post(BASE_URI + "/id/find")
 					.content(objectMapper.writeValueAsString(findLoginId))
 					.contentType(MediaType.APPLICATION_JSON));
 
@@ -416,7 +416,7 @@ class AuthControllerTest extends RestDocsSupport {
 
 			//when
 			ResultActions actions = mockMvc.perform(
-				post(BASE_URI + "/find-id")
+				post(BASE_URI + "/id/find")
 					.content(objectMapper.writeValueAsString(findLoginId))
 					.contentType(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/com/hello/boilerplate/auth/presentation/AuthControllerTest.java
@@ -6,7 +6,9 @@ import com.epages.restdocs.apispec.Schema;
 import com.hello.boilerplate.auth.presentation.dto.request.AuthenticateUser;
 import com.hello.boilerplate.auth.presentation.dto.request.FindLoginId;
 import com.hello.boilerplate.auth.presentation.dto.request.FindPassword;
+import com.hello.boilerplate.auth.presentation.dto.request.VerifyPasswordCode;
 import com.hello.boilerplate.auth.presentation.dto.response.AuthenticationResult;
+import com.hello.boilerplate.auth.presentation.dto.response.PasswordCodeVerified;
 import com.hello.boilerplate.auth.presentation.dto.response.ReissuedToken;
 import com.hello.boilerplate.common.exception.CustomException;
 import com.hello.boilerplate.common.exception.NotFoundException;
@@ -506,6 +508,93 @@ class AuthControllerTest extends RestDocsSupport {
 			actions
 				.andExpect(status().isNotFound())
 				.andExpect(result -> Assertions.assertInstanceOf(NotFoundException.class, result.getResolvedException()))
+				.andExpect(jsonPath("$.message").value(errorMessage))
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.responseSchema(Schema.schema(ApiErrorResponse.class.getSimpleName()))
+							.build())
+					)
+				);
+		}
+	}
+
+	@Nested
+	@DisplayName("인증 번호 검증 기능 API 테스트")
+	class verifyCode {
+		@Test
+		void 인증번호_검증_2XX() throws Exception {
+			//given
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String loginId = userFixture.getLoginId();
+			String code = "123456";
+
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(loginId, code);
+
+			String token = "testToken";
+			PasswordCodeVerified passwordCodeVerified = new PasswordCodeVerified(token);
+			Mockito.when(accountRecoveryService.verifyCode(verifyPasswordCode)).thenReturn(passwordCodeVerified);
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/verify")
+					.content(objectMapper.writeValueAsString(verifyPasswordCode))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.message").value(BASE_SUCCESS_MESSAGE))
+				.andExpect(jsonPath("$.data").isNotEmpty())
+				.andDo(restDocsHandler.document(
+						ResourceDocumentation.resource(ResourceSnippetParameters.builder()
+							.tag(BASE_TAG)
+							.summary("2. 인증번호 검증")
+							.description("## 2. 인증 번호 검증 기능 \n"
+								+ "### 사용법 \n"
+								+ "- 비밀번호 찾기를 통해 얻은 인증 번호를 검증합니다.\n"
+								+ "- 인증 번호가 인증되면 유효기간 10분의 임시 토큰이 발행됩니다.\n"
+							)
+							.requestSchema(Schema.schema(VerifyPasswordCode.class.getSimpleName()))
+							.requestFields(
+								fieldWithPath("loginId").description("사용자의 아이디입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("code").description("비밀번호 찾기를 통해 얻은 인증번호입니다.").type(JsonFieldType.STRING)
+							)
+							.responseSchema(Schema.schema(PasswordCodeVerified.class.getSimpleName()))
+							.responseFields(
+								fieldWithPath("message").description("성공 응답 메세지입니다.").type(JsonFieldType.STRING),
+								fieldWithPath("data.token").description("비밀번호 리셋을 위한 임시 토큰입니다.").type(JsonFieldType.STRING)
+							)
+							.build()
+						)
+					)
+				);
+
+		}
+
+		@Test
+		void 인증번호_검증_4XX_인증번호가_올바르지_않은_경우() throws Exception {
+			//given
+			String errorMessage = "인증번호가 올바르지 않습니다.";
+
+			User userFixture = UserFixture.USER_FIXTURE_1.create();
+			String loginId = userFixture.getLoginId();
+			String wrongCode = "654321";
+
+			VerifyPasswordCode verifyPasswordCode = new VerifyPasswordCode(loginId, wrongCode);
+			Mockito.when(accountRecoveryService.verifyCode(verifyPasswordCode))
+				.thenThrow(new CustomException(HttpStatus.BAD_REQUEST, errorMessage));
+
+			//when
+			ResultActions actions = mockMvc.perform(
+				post(BASE_URI + "/password/verify")
+					.content(objectMapper.writeValueAsString(verifyPasswordCode))
+					.contentType(MediaType.APPLICATION_JSON));
+
+			//then
+			actions
+				.andExpect(status().isBadRequest())
+				.andExpect(result -> Assertions.assertInstanceOf(CustomException.class, result.getResolvedException()))
 				.andExpect(jsonPath("$.message").value(errorMessage))
 				.andDo(restDocsHandler.document(
 						ResourceDocumentation.resource(ResourceSnippetParameters.builder()

--- a/src/test/java/com/hello/boilerplate/support/RestDocsSupport.java
+++ b/src/test/java/com/hello/boilerplate/support/RestDocsSupport.java
@@ -3,6 +3,7 @@ package com.hello.boilerplate.support;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hello.boilerplate.auth.application.AccountRecoveryService;
 import com.hello.boilerplate.common.infrastructure.config.SecurityConfig;
 import com.hello.boilerplate.auth.presentation.AuthController;
 import com.hello.boilerplate.auth.infrastructure.security.AccessDeniedHandlerImpl;
@@ -85,6 +86,9 @@ public abstract class RestDocsSupport {
 
     @MockitoBean
     protected AuthService authService;
+
+	@MockitoBean
+	protected AccountRecoveryService accountRecoveryService;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#49 ](이슈 링크)

### 변경 사항

### 1. 아이디 찾기 기능 추가
사용자가 입력한 이메일로 해당 계정의 로그인 아이디(LoginId) 를 전송하는 기능을 구현했습니다.

### 2. 비밀번호 찾기(초기화) 기능 전체 구현

2-1. 비밀번호 찾기 요청 (인증번호 발송)
사용자가 이메일을 제출하면 6자리 인증번호를 생성하여 해당 이메일로 발송합니다.
인증번호는 Redis에 저장하며 TTL 5분을 적용했습니다.

2-2. 인증번호 검증 및 임시 토큰 발급
입력한 인증번호가 Redis에 저장된 값과 일치하면 인증 성공으로 처리합니다.
인증 성공 시 비밀번호 초기화 전용 임시 JWT 토큰(Verification Token) 을 발급합니다.
JWT subject: loginId
purpose: PASSWORD_RESET
임시 토큰은 AccessToken/RefreshToken과 분리된 토큰입니다.

2-3. 비밀번호 초기화 처리
클라이언트에서 resetPassword 요청 시 임시 토큰 + 새 비밀번호를 전달합니다.
토큰 검증 후 해당 유저의 비밀번호를 새롭게 리셋합니다.


### 테스트 결과
<img width="697" height="276" alt="스크린샷 2025-11-29 오전 4 30 32" src="https://github.com/user-attachments/assets/5ecb2301-70b9-4fe7-9b0a-6740532879c2" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일로 로그인 ID 조회 및 6자리 인증번호 기반 비밀번호 찾기/재설정 흐름 추가
  * 검증 토큰 발급·검증 기능 추가
  * 관련 REST 엔드포인트와 요청/응답 DTO 추가

* **개선사항**
  * 비밀번호 관련 이메일 템플릿 추가 및 메일 발송 비동기 처리
  * 검증 코드 저장/조회용 Redis 기반 저장소 도입
  * 보안 토큰 처리(클레임 키명 정리) 개선

* **테스트**
  * 계정 복구 흐름에 대한 단위 및 통합 테스트 대폭 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->