### PR TITLE
[#53] API 문서 배포 시간 타임존 서울로 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,12 +84,12 @@ def extractDomainFromYaml() {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:8080" },
-            { url = extractDomainFromYaml() }
+            { url = extractDomainFromYaml() },
+            { url = "http://localhost:8080" }
     ]
     title = 'Boiler Plate API'
     description = 'Boiler Plate API'
-    version = new Date().format("yyyy.MM.dd HH:mm")
+    version = new Date().format("yyyy.MM.dd HH:mm", TimeZone.getTimeZone("Asia/Seoul"))
     format = 'yaml'
 }
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
develop

### 이슈
[#53 ](이슈 링크)

### 변경 사항
문서 배포 시간 타임존을 서울로 설정했습니다.

### 테스트 결과
develop 브렌치 merge에 트리거가 되어 API 문서가 배포되고 있습니다.
따라서 로컬에서 UTC로 변경하며 테스트를 진행했습니다.
테스트 시간은 대략 한국 시간 18시에 진행했습니다.

<img width="339" height="112" alt="스크린샷 2025-11-30 오후 6 05 05" src="https://github.com/user-attachments/assets/49fdda21-40a4-41c6-ab6a-548ce644b032" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **기타**
  * API 엔드포인트 문서의 서버 목록 표시 순서가 업데이트되었습니다.
  * 버전 정보의 타임스탐프 형식이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->